### PR TITLE
fix: Expose method to get recipient key id in SessionEnvelopedData

### DIFF
--- a/src/lib/crypto_wrappers/cms/envelopedData.spec.ts
+++ b/src/lib/crypto_wrappers/cms/envelopedData.spec.ts
@@ -436,6 +436,13 @@ describe('SessionEnvelopedData', () => {
     });
   });
 
+  test('getRecipientKeyId() should return the recipient key id', async () => {
+    const { envelopedData } = await SessionEnvelopedData.encrypt(plaintext, bobDhCertificate);
+
+    const actualKeyId = envelopedData.getRecipientKeyId();
+    expect(actualKeyId).toEqual(bobDhCertificate.pkijsCertificate.serialNumber.valueBlock.valueDec);
+  });
+
   describe('decrypt', () => {
     test('Decryption with the wrong private key should fail', async () => {
       const differentDhKeyPair = await generateECDHKeyPair();

--- a/src/lib/crypto_wrappers/cms/envelopedData.ts
+++ b/src/lib/crypto_wrappers/cms/envelopedData.ts
@@ -168,6 +168,12 @@ export class SessionEnvelopedData extends EnvelopedData {
     return { keyId, publicKeyDer };
   }
 
+  public getRecipientKeyId(): number {
+    const recipientCertificate = this.pkijsEnvelopedData.recipientInfos[0].value
+      .recipientCertificate;
+    return convertAsn1IntegerToNumber(recipientCertificate.serialNumber);
+  }
+
   public async decrypt(
     privateKey: CryptoKey,
     dhRecipientCertificate: Certificate,
@@ -220,7 +226,11 @@ function extractOriginatorKeyId(envelopedData: pkijs.EnvelopedData): number {
     );
   }
 
-  const keyIdString = originatorKeyIds[0].valueBlock.toString();
+  return convertAsn1IntegerToNumber(originatorKeyIds[0]);
+}
+
+function convertAsn1IntegerToNumber(asn1Integer: asn1js.Integer): number {
+  const keyIdString = asn1Integer.valueBlock.toString();
   return parseInt(keyIdString, 10);
 }
 


### PR DESCRIPTION
Needed by https://github.com/relaycorp/relaynet-pong/pull/15