### PR TITLE
fix: Represent message fields as ASN.1/DER values

### DIFF
--- a/src/lib/_test_utils.ts
+++ b/src/lib/_test_utils.ts
@@ -88,6 +88,7 @@ export function expectBuffersToEqual(
   buffer1: Buffer | ArrayBuffer,
   buffer2: Buffer | ArrayBuffer,
 ): void {
+  expect(buffer1.byteLength).toEqual(buffer2.byteLength);
   if (buffer1 instanceof Buffer) {
     expect(buffer2).toBeInstanceOf(Buffer);
     expect(buffer1.equals(buffer2 as Buffer)).toBeTrue();

--- a/src/lib/crypto_wrappers/cms/_test_utils.ts
+++ b/src/lib/crypto_wrappers/cms/_test_utils.ts
@@ -1,5 +1,15 @@
+import * as asn1js from 'asn1js';
 import * as pkijs from 'pkijs';
+
 import { deserializeDer } from '../_utils';
+
+export function serializeContentInfo(
+  content: asn1js.LocalBaseBlock,
+  contentType: string,
+): ArrayBuffer {
+  const contentInfo = new pkijs.ContentInfo({ content, contentType });
+  return contentInfo.toSchema().toBER(false);
+}
 
 export function deserializeContentInfo(contentInfoDer: ArrayBuffer): pkijs.ContentInfo {
   return new pkijs.ContentInfo({ schema: deserializeDer(contentInfoDer) });

--- a/src/lib/crypto_wrappers/cms/signedData.spec.ts
+++ b/src/lib/crypto_wrappers/cms/signedData.spec.ts
@@ -6,6 +6,7 @@ import * as pkijs from 'pkijs';
 
 import {
   expectAsn1ValuesToBeEqual,
+  expectBuffersToEqual,
   expectPkijsValuesToBeEqual,
   expectPromiseToReject,
   generateStubCert,
@@ -14,7 +15,7 @@ import {
 import * as oids from '../../oids';
 import { generateRSAKeyPair } from '../keys';
 import Certificate from '../x509/Certificate';
-import { deserializeContentInfo } from './_test_utils';
+import { deserializeContentInfo, serializeContentInfo } from './_test_utils';
 import CMSError from './CMSError';
 import { sign, verifySignature } from './signedData';
 
@@ -77,16 +78,6 @@ describe('sign', () => {
         signerInfo.sid.serialNumber,
         certificate.pkijsCertificate.serialNumber,
       );
-    });
-
-    test('Content should be detached', async () => {
-      jest.spyOn(pkijs.SignedData.prototype, 'sign');
-      const contentInfoDer = await sign(plaintext, privateKey, certificate);
-
-      const signedData = deserializeSignedData(contentInfoDer);
-      expect(signedData.encapContentInfo).toBeInstanceOf(pkijs.EncapsulatedContentInfo);
-      expect(signedData.encapContentInfo).toHaveProperty('eContentType', oids.CMS_DATA);
-      expect(signedData.encapContentInfo).not.toHaveProperty('eContent');
     });
 
     describe('SignedAttributes', () => {
@@ -206,35 +197,79 @@ describe('sign', () => {
       }
     });
   });
+
+  test('Content should be attached', async () => {
+    jest.spyOn(pkijs.SignedData.prototype, 'sign');
+    const contentInfoDer = await sign(plaintext, privateKey, certificate);
+
+    const signedData = deserializeSignedData(contentInfoDer);
+    expect(signedData.encapContentInfo).toBeInstanceOf(pkijs.EncapsulatedContentInfo);
+    expect(signedData.encapContentInfo).toHaveProperty('eContentType', oids.CMS_DATA);
+    expect(signedData.encapContentInfo).toHaveProperty('eContent');
+    const plaintextOctetString = signedData.encapContentInfo.eContent.valueBlock.value[0];
+    expectBuffersToEqual(
+      (plaintextOctetString as asn1js.OctetString).valueBlock.valueHex,
+      plaintext,
+    );
+  });
 });
 
 describe('verifySignature', () => {
   test('A non-DER-encoded value should be refused', async () => {
     const invalidSignature = bufferToArray(Buffer.from('nope.jpeg'));
     await expectPromiseToReject(
-      verifySignature(invalidSignature, plaintext),
+      verifySignature(invalidSignature),
       new CMSError('Could not deserialize CMS ContentInfo: Value is not DER-encoded'),
     );
   });
 
   test('Well-formed but invalid signatures should be rejected', async () => {
+    // Let's tamper with the payload
+    const signatureDer = await sign(plaintext, privateKey, certificate);
     const differentPlaintext = bufferToArray(Buffer.from('Different'));
-    const signatureDer = await sign(differentPlaintext, privateKey, certificate);
+    const cmsSignedData = deserializeSignedData(signatureDer);
+    // tslint:disable-next-line:no-object-mutation
+    cmsSignedData.encapContentInfo = new pkijs.EncapsulatedContentInfo({
+      eContent: new asn1js.OctetString({ valueHex: differentPlaintext }),
+      eContentType: oids.CMS_DATA,
+    });
+    const invalidCmsSignedDataSerialized = serializeContentInfo(
+      cmsSignedData.toSchema(true),
+      oids.CMS_SIGNED_DATA,
+    );
+
     await expectPromiseToReject(
-      verifySignature(signatureDer, plaintext),
+      verifySignature(invalidCmsSignedDataSerialized),
       new CMSError('Invalid signature:  (PKI.js code: 14)'),
     );
   });
 
   test('Valid signatures should be accepted', async () => {
     const signatureDer = await sign(plaintext, privateKey, certificate);
-    await verifySignature(signatureDer, plaintext);
+    await verifySignature(signatureDer);
+  });
+
+  test('Plaintext should be output when verification passes', async () => {
+    const signatureDer = await sign(plaintext, privateKey, certificate);
+
+    const signatureVerification = await verifySignature(signatureDer);
+
+    expectBuffersToEqual(signatureVerification.plaintext, plaintext);
+  });
+
+  test('Large plaintexts chunked by PKI.js should be put back together', async () => {
+    const largePlaintext = bufferToArray(Buffer.from('a'.repeat(2 ** 20)));
+    const signatureDer = await sign(largePlaintext, privateKey, certificate);
+
+    const signatureVerification = await verifySignature(signatureDer);
+
+    expectBuffersToEqual(signatureVerification.plaintext, largePlaintext);
   });
 
   test('Signer certificate should be output when verification passes', async () => {
     const signatureDer = await sign(plaintext, privateKey, certificate);
 
-    const { signerCertificate } = await verifySignature(signatureDer, plaintext);
+    const { signerCertificate } = await verifySignature(signatureDer);
 
     expectPkijsValuesToBeEqual(signerCertificate.pkijsCertificate, certificate.pkijsCertificate);
   });
@@ -263,7 +298,7 @@ describe('verifySignature', () => {
       rootCaCertificate,
     ]);
 
-    const { attachedCertificates } = await verifySignature(signatureDer, plaintext);
+    const { attachedCertificates } = await verifySignature(signatureDer);
 
     expect(attachedCertificates).toHaveLength(3);
     expectPkijsValuesToBeEqual(

--- a/src/lib/crypto_wrappers/cms/signedData.ts
+++ b/src/lib/crypto_wrappers/cms/signedData.ts
@@ -108,11 +108,7 @@ export async function verifySignature(
   // tslint:disable-next-line:no-let
   let verificationResult;
   try {
-    verificationResult = await signedData.verify({
-      extendedMode: true,
-      includeSignerCertificate: true,
-      signer: 0,
-    });
+    verificationResult = await signedData.verify({ extendedMode: true, signer: 0 });
 
     if (!verificationResult.signatureVerified) {
       throw verificationResult;

--- a/src/lib/messages/CargoMessageSet.spec.ts
+++ b/src/lib/messages/CargoMessageSet.spec.ts
@@ -170,7 +170,7 @@ describe('CargoMessageSet', () => {
         convertAsyncIteratorToArray(cargoMessageSet.deserializeMessages()),
       ).rejects.toMatchObject<Partial<InvalidMessageError>>({
         message: expect.stringMatching(
-          /^Invalid message found: Serialization is not a valid RAMF message/,
+          /^Invalid message found: Serialization starts with invalid RAMF format signature/,
         ),
       });
     });

--- a/src/lib/messages/CargoMessageSet.spec.ts
+++ b/src/lib/messages/CargoMessageSet.spec.ts
@@ -72,8 +72,8 @@ describe('CargoMessageSet', () => {
       const invalidSerialization = bufferToArray(Buffer.from('I pretend to be valid'));
 
       expect(() => CargoMessageSet.deserialize(invalidSerialization)).toThrowWithMessage(
-        Error,
-        'Value is not DER-encoded',
+        InvalidMessageError,
+        'Serialization is not a valid CargoMessageSet',
       );
     });
 

--- a/src/lib/messages/CargoMessageSet.ts
+++ b/src/lib/messages/CargoMessageSet.ts
@@ -1,7 +1,6 @@
 import * as asn1js from 'asn1js';
 import bufferToArray from 'buffer-to-arraybuffer';
 
-import { deserializeDer } from '../crypto_wrappers/_utils';
 import InvalidMessageError from './InvalidMessageError';
 import Parcel from './Parcel';
 import PayloadPlaintext from './PayloadPlaintext';
@@ -13,8 +12,7 @@ import PayloadPlaintext from './PayloadPlaintext';
  */
 export default class CargoMessageSet implements PayloadPlaintext {
   public static deserialize(serialization: ArrayBuffer): CargoMessageSet {
-    const asn1Value = deserializeDer(serialization);
-    const result = asn1js.compareSchema(asn1Value, asn1Value, CargoMessageSet.ASN1_SCHEMA);
+    const result = asn1js.verifySchema(serialization, CargoMessageSet.ASN1_SCHEMA);
     if (!result.verified) {
       throw new InvalidMessageError('Serialization is not a valid CargoMessageSet');
     }

--- a/src/lib/ramf/RAMFValidationError.ts
+++ b/src/lib/ramf/RAMFValidationError.ts
@@ -1,15 +1,6 @@
 import RAMFError from './RAMFError';
-import { MessageFields } from './serialization';
 
 /**
  * Error while validating RAMF message.
  */
-export default class RAMFValidationError extends RAMFError {
-  constructor(
-    message: string,
-    readonly invalidMessageFields: MessageFields,
-    cause: Error | null = null,
-  ) {
-    super({ cause }, message);
-  }
-}
+export default class RAMFValidationError extends RAMFError {}

--- a/src/lib/ramf/_test_utils.ts
+++ b/src/lib/ramf/_test_utils.ts
@@ -5,8 +5,6 @@ import { SignatureOptions } from '../..';
 import Message from '../messages/Message';
 import PayloadPlaintext from '../messages/PayloadPlaintext';
 
-export const NON_ASCII_STRING = '❤こんにちは'; // Multi-byte characters
-
 export class StubPayload implements PayloadPlaintext {
   constructor(public readonly content: ArrayBuffer) {}
 

--- a/src/lib/ramf/serialization.spec.ts
+++ b/src/lib/ramf/serialization.spec.ts
@@ -216,8 +216,8 @@ describe('MessageSerializer', () => {
       });
 
       describe('Message id', () => {
-        test('Id should be up to 8 bits long', async () => {
-          const idLength = 2 ** 8 - 1;
+        test('Id should be up to 64 characters long', async () => {
+          const idLength = 64;
           const id = 'a'.repeat(idLength);
           const stubMessage = new StubMessage(recipientAddress, senderCertificate, PAYLOAD, { id });
 
@@ -232,8 +232,8 @@ describe('MessageSerializer', () => {
           expect(messageParts).toHaveProperty('id', stubMessage.id);
         });
 
-        test('A custom id with a length greater than 8 bits should be refused', async () => {
-          const id = 'a'.repeat(2 ** 8);
+        test('Ids longer than 64 characters should be refused', async () => {
+          const id = 'a'.repeat(65);
           const stubMessage = new StubMessage(recipientAddress, senderCertificate, PAYLOAD, { id });
 
           await expectPromiseToReject(
@@ -243,7 +243,7 @@ describe('MessageSerializer', () => {
               stubConcreteMessageVersionOctet,
               senderPrivateKey,
             ),
-            new RAMFSyntaxError('Custom id exceeds maximum length'),
+            new RAMFSyntaxError('Id should not span more than 64 characters (got 65)'),
           );
         });
 

--- a/src/lib/ramf/serialization.spec.ts
+++ b/src/lib/ramf/serialization.spec.ts
@@ -389,7 +389,7 @@ describe('MessageSerializer', () => {
       describe('Payload', () => {
         test('Payload can span up to 8 MiB', async () => {
           // This test is painfully slow: https://github.com/relaycorp/relaynet-core-js/issues/57
-          jest.setTimeout(8000);
+          jest.setTimeout(7000);
 
           const largePayload = Buffer.from('a'.repeat(MAX_PAYLOAD_LENGTH));
           const message = new StubMessage(recipientAddress, senderCertificate, largePayload);

--- a/src/lib/ramf/serialization.ts
+++ b/src/lib/ramf/serialization.ts
@@ -215,8 +215,8 @@ function validateRecipientAddressLength(recipientAddress: string): void {
   const length = Buffer.byteLength(recipientAddress);
   if (MAX_RECIPIENT_ADDRESS_LENGTH < length) {
     throw new RAMFSyntaxError(
-      `Recipient address should not span more than ${MAX_RECIPIENT_ADDRESS_LENGTH} octets `+
-      `(got ${length})`,
+      `Recipient address should not span more than ${MAX_RECIPIENT_ADDRESS_LENGTH} octets ` +
+        `(got ${length})`,
     );
   }
 }

--- a/src/lib/ramf/serialization.ts
+++ b/src/lib/ramf/serialization.ts
@@ -9,7 +9,7 @@ import RAMFValidationError from './RAMFValidationError';
 
 const MAX_MESSAGE_LENGTH = 9437184; // 9 MiB
 const MAX_RECIPIENT_ADDRESS_LENGTH = 1024;
-const MAX_ID_LENGTH = 2 ** 8 - 1;
+const MAX_ID_LENGTH = 64;
 const MAX_DATE_TIMESTAMP_SEC = 2 ** 32 - 1;
 const MAX_TTL = 2 ** 24 - 1;
 const MAX_PAYLOAD_LENGTH = 2 ** 23 - 1; // 8 MiB
@@ -222,8 +222,11 @@ function validateRecipientAddressLength(recipientAddress: string): void {
 }
 
 function validateMessageIdLength(messageId: string): void {
-  if (MAX_ID_LENGTH < messageId.length) {
-    throw new RAMFSyntaxError('Custom id exceeds maximum length');
+  const length = messageId.length;
+  if (MAX_ID_LENGTH < length) {
+    throw new RAMFSyntaxError(
+      `Id should not span more than ${MAX_ID_LENGTH} characters (got ${length})`,
+    );
   }
 }
 

--- a/src/lib/ramf/serialization.ts
+++ b/src/lib/ramf/serialization.ts
@@ -8,7 +8,7 @@ import RAMFSyntaxError from './RAMFSyntaxError';
 import RAMFValidationError from './RAMFValidationError';
 
 const MAX_MESSAGE_LENGTH = 9437184; // 9 MiB
-const MAX_RECIPIENT_ADDRESS_LENGTH = 2 ** 10 - 1;
+const MAX_RECIPIENT_ADDRESS_LENGTH = 1024;
 const MAX_ID_LENGTH = 2 ** 8 - 1;
 const MAX_DATE_TIMESTAMP_SEC = 2 ** 32 - 1;
 const MAX_TTL = 2 ** 24 - 1;
@@ -212,8 +212,12 @@ function validateFileFormatSignature(
 }
 
 function validateRecipientAddressLength(recipientAddress: string): void {
-  if (MAX_RECIPIENT_ADDRESS_LENGTH < Buffer.byteLength(recipientAddress)) {
-    throw new RAMFSyntaxError('Recipient address exceeds maximum length');
+  const length = Buffer.byteLength(recipientAddress);
+  if (MAX_RECIPIENT_ADDRESS_LENGTH < length) {
+    throw new RAMFSyntaxError(
+      `Recipient address should not span more than ${MAX_RECIPIENT_ADDRESS_LENGTH} octets `+
+      `(got ${length})`,
+    );
   }
 }
 


### PR DESCRIPTION
Per https://github.com/relaynet/specs/pull/52

TODO:

- [x] Enforce field max lengths.