### PR TITLE
fix: Downgrade PKI.js to work around integration issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10647,9 +10647,9 @@
       }
     },
     "pkijs": {
-      "version": "2.1.88",
-      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-2.1.88.tgz",
-      "integrity": "sha512-R/1VglrBioIx3wdX1/DzEcJDvhJgl5cNsT+Ovex3zWbCwjY2mDUW2Qvj6/kc0S7PDDnijXwHczAVRYscNLhUgQ==",
+      "version": "2.1.84",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-2.1.84.tgz",
+      "integrity": "sha512-DRfTYTBaoVv65SkBggpr8nBEt18U9Is97pbGqi4Mu3ZoIsgAmqufQlMMNwPXit9mVS/3H3+cvvwDg77ICDi4Hw==",
       "requires": {
         "asn1js": "^2.0.26",
         "bytestreamjs": "^1.0.29",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "binary-parser": "^1.5.0",
     "buffer-to-arraybuffer": "0.0.5",
     "node-webcrypto-ossl": "^1.0.49",
-    "pkijs": "^2.1.88",
+    "pkijs": "^2.1.84",
     "smart-buffer": "^4.1.0",
     "uuid4": "^1.1.4",
     "verror": "^1.10.0"


### PR DESCRIPTION
relaycorp/relaynet-internet-gateway#25 broke with the last couple of releases: relaycorp/relaynet-internet-gateway@9ea7641

This fixes that, although for some bizarre reason the last release works perfectly in relaynet-pong. :man_shrugging:
