### PR TITLE
fix(RAMF): Remove duplicated validation of validity period

### DIFF
--- a/src/lib/messages/Message.spec.ts
+++ b/src/lib/messages/Message.spec.ts
@@ -185,64 +185,6 @@ describe('Message', () => {
   });
 
   describe('validate', () => {
-    describe('Validity period', () => {
-      const NOW = new Date();
-      NOW.setMilliseconds(0);
-      beforeEach(() => jestDateMock.advanceTo(NOW));
-
-      test('Creation date in the future should be refused', async () => {
-        const tomorrow = new Date(NOW);
-        tomorrow.setDate(tomorrow.getDate() + 1);
-        const message = new StubMessage(
-          await stubSenderChain.recipientCert.calculateSubjectPrivateAddress(),
-          reSerializeCertificate(senderCertificate),
-          STUB_PAYLOAD_PLAINTEXT,
-          { date: tomorrow },
-        );
-
-        await expect(message.validate()).rejects.toEqual(
-          new InvalidMessageError('Message creation date should be in the past'),
-        );
-      });
-
-      test('Expiry date in the past should be refused', async () => {
-        const yesterday = new Date(NOW);
-        yesterday.setDate(yesterday.getDate() - 1);
-        const message = new StubMessage(
-          await stubSenderChain.recipientCert.calculateSubjectPrivateAddress(),
-          reSerializeCertificate(senderCertificate),
-          STUB_PAYLOAD_PLAINTEXT,
-          { date: yesterday, ttl: 1 },
-        );
-
-        await expect(message.validate()).rejects.toEqual(
-          new InvalidMessageError('Message expiry date should be in the future'),
-        );
-      });
-
-      test('Creation date matching current time should be accepted', async () => {
-        const message = new StubMessage(
-          await stubSenderChain.recipientCert.calculateSubjectPrivateAddress(),
-          reSerializeCertificate(senderCertificate),
-          STUB_PAYLOAD_PLAINTEXT,
-          { date: NOW, ttl: 1 },
-        );
-
-        await expect(message.validate()).toResolve();
-      });
-
-      test('Expiry date matching current time should be accepted', async () => {
-        const message = new StubMessage(
-          await stubSenderChain.recipientCert.calculateSubjectPrivateAddress(),
-          reSerializeCertificate(senderCertificate),
-          STUB_PAYLOAD_PLAINTEXT,
-          { date: NOW, ttl: 0 },
-        );
-
-        await expect(message.validate()).toResolve();
-      });
-    });
-
     describe('Authorization', () => {
       test('Parcel should be refused if sender is not trusted', async () => {
         const message = new StubMessage(

--- a/src/lib/messages/Message.ts
+++ b/src/lib/messages/Message.ts
@@ -99,7 +99,6 @@ export default abstract class Message<Payload extends PayloadPlaintext> {
    *   the message based on the trusted certificates.
    */
   public async validate(trustedCertificates?: readonly Certificate[]): Promise<void> {
-    this.validateValidityPeriod();
     if (trustedCertificates) {
       await this.validateAuthorization(trustedCertificates);
     }
@@ -119,17 +118,9 @@ export default abstract class Message<Payload extends PayloadPlaintext> {
 
   protected abstract deserializePayload(payloadPlaintext: ArrayBuffer): Payload;
 
-  private validateValidityPeriod(): void {
-    const now = new Date();
-    if (now < this.date) {
-      throw new InvalidMessageError('Message creation date should be in the past');
-    }
-    if (this.expiryDate < now) {
-      throw new InvalidMessageError('Message expiry date should be in the future');
-    }
-  }
-
-  private async validateAuthorization(trustedCertificates: readonly Certificate[]): Promise<void> {
+  protected async validateAuthorization(
+    trustedCertificates: readonly Certificate[],
+  ): Promise<void> {
     // tslint:disable-next-line:no-let
     let certificationPath: readonly Certificate[];
     try {

--- a/src/lib/ramf/serialization.ts
+++ b/src/lib/ramf/serialization.ts
@@ -270,6 +270,7 @@ async function verifySignature(
   }
 }
 
+// TODO: Consider moving this into `Message.validate()` to make timing validation optional
 function validateMessageTiming(
   messageFields: MessageFieldSet,
   signatureVerification: cmsSignedData.SignatureVerification,


### PR DESCRIPTION
#65 accidentally duplicated the validation that was already part of the post-deserialization process per RS-001 anyway.