### PR TITLE
fix(PrivateKeyStore): Distinguish invalid keys from lookup errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export * from './lib/keyStores/privateKeyStore';
 export * from './lib/keyStores/publicKeyStore';
 export * from './lib/keyStores/testMocks';
 export { default as PublicKeyStoreError } from './lib/keyStores/PublicKeyStoreError';
+export { default as UnknownKeyError } from './lib/keyStores/UnknownKeyError';
 
 export * from './lib/cargoRelay';
 

--- a/src/lib/keyStores/UnknownKeyError.ts
+++ b/src/lib/keyStores/UnknownKeyError.ts
@@ -1,0 +1,3 @@
+import RelaynetError from '../RelaynetError';
+
+export default class UnknownKeyError extends RelaynetError {}

--- a/src/lib/keyStores/privateKeyStore.spec.ts
+++ b/src/lib/keyStores/privateKeyStore.spec.ts
@@ -247,39 +247,37 @@ describe('PrivateKeyStore', () => {
       });
     });
 
-    describe('Subsequent session keys', () => {
-      describe('saveSubsequentSessionKey', () => {
-        test('Bound key should be stored', async () => {
-          const store = new MockPrivateKeyStore();
+    describe('saveSubsequentSessionKey', () => {
+      test('Bound key should be stored', async () => {
+        const store = new MockPrivateKeyStore();
 
-          await store.saveSubsequentSessionKey(
+        await store.saveSubsequentSessionKey(
+          PRIVATE_KEY,
+          CERTIFICATE.getSerialNumber(),
+          stubRecipientCertificate,
+        );
+
+        const expectedKey: BoundPrivateKeyData = {
+          keyDer: await keys.derSerializePrivateKey(PRIVATE_KEY),
+          recipientPublicKeyDigest: await keys.getPublicKeyDigestHex(
+            await stubRecipientCertificate.getPublicKey(),
+          ),
+          type: 'session-subsequent',
+        };
+        expect(store.keys[CERTIFICATE.getSerialNumberHex()]).toEqual(expectedKey);
+      });
+
+      test('Errors should be wrapped', async () => {
+        const store = new MockPrivateKeyStore(true);
+
+        await expectPromiseToReject(
+          store.saveSubsequentSessionKey(
             PRIVATE_KEY,
             CERTIFICATE.getSerialNumber(),
             stubRecipientCertificate,
-          );
-
-          const expectedKey: BoundPrivateKeyData = {
-            keyDer: await keys.derSerializePrivateKey(PRIVATE_KEY),
-            recipientPublicKeyDigest: await keys.getPublicKeyDigestHex(
-              await stubRecipientCertificate.getPublicKey(),
-            ),
-            type: 'session-subsequent',
-          };
-          expect(store.keys[CERTIFICATE.getSerialNumberHex()]).toEqual(expectedKey);
-        });
-
-        test('Errors should be wrapped', async () => {
-          const store = new MockPrivateKeyStore(true);
-
-          await expectPromiseToReject(
-            store.saveSubsequentSessionKey(
-              PRIVATE_KEY,
-              CERTIFICATE.getSerialNumber(),
-              stubRecipientCertificate,
-            ),
-            new PrivateKeyStoreError(`Failed to save key: Denied`),
-          );
-        });
+          ),
+          new PrivateKeyStoreError(`Failed to save key: Denied`),
+        );
       });
     });
   });

--- a/src/lib/keyStores/testMocks.ts
+++ b/src/lib/keyStores/testMocks.ts
@@ -9,7 +9,7 @@ export class MockPrivateKeyStore extends PrivateKeyStore {
   // tslint:disable-next-line:readonly-keyword
   public readonly keys: { [key: string]: PrivateKeyData } = {};
 
-  constructor(protected readonly failOnSave = false) {
+  constructor(protected readonly failOnSave = false, protected readonly failOnFetch = false) {
     super();
   }
 
@@ -49,11 +49,11 @@ export class MockPrivateKeyStore extends PrivateKeyStore {
     };
   }
 
-  protected async fetchKey(keyId: string): Promise<PrivateKeyData> {
-    if (keyId in this.keys) {
-      return this.keys[keyId];
+  protected async fetchKey(keyId: string): Promise<PrivateKeyData | null> {
+    if (this.failOnFetch) {
+      throw new Error('Denied');
     }
-    throw new Error(`Unknown key ${keyId}`);
+    return this.keys[keyId] ?? null;
   }
 
   protected async saveKey(privateKeyData: PrivateKeyData, keyId: string): Promise<void> {


### PR DESCRIPTION
Needed for https://github.com/relaycorp/relaynet-internet-gateway/issues/38