### PR TITLE
fix(RAMF): Exclude sender's certificate from chain

### DIFF
--- a/src/lib/messages/RAMFMessage.spec.ts
+++ b/src/lib/messages/RAMFMessage.spec.ts
@@ -131,13 +131,25 @@ describe('RAMFMessage', () => {
       });
 
       test('A custom sender certificate chain should be accepted', async () => {
-        const chain: readonly Certificate[] = [await generateStubCert(), senderCertificate];
+        const chain: readonly Certificate[] = [await generateStubCert(), await generateStubCert()];
+        const message = new StubMessage(
+          recipientAddress,
+          senderCertificate,
+          STUB_PAYLOAD_PLAINTEXT,
+          { senderCaCertificateChain: chain },
+        );
+
+        expect(message.senderCaCertificateChain).toEqual(chain);
+      });
+
+      test('Sender certificate should be excluded from chain if included', async () => {
+        const chain: readonly Certificate[] = [await generateStubCert()];
         const message = new StubMessage(
           recipientAddress,
           senderCertificate,
           STUB_PAYLOAD_PLAINTEXT,
           {
-            senderCaCertificateChain: chain,
+            senderCaCertificateChain: [...chain, senderCertificate],
           },
         );
 

--- a/src/lib/messages/RAMFMessage.ts
+++ b/src/lib/messages/RAMFMessage.ts
@@ -40,7 +40,8 @@ export default abstract class RAMFMessage<Payload extends PayloadPlaintext> {
     this.creationDate = options.creationDate || new Date();
     this.ttl = options.ttl !== undefined ? options.ttl : DEFAULT_TTL_SECONDS;
 
-    this.senderCaCertificateChain = options.senderCaCertificateChain ?? [];
+    this.senderCaCertificateChain =
+      options.senderCaCertificateChain?.filter((c) => !c.isEqual(senderCertificate)) ?? [];
   }
 
   get expiryDate(): Date {

--- a/src/lib/ramf/serialization.spec.ts
+++ b/src/lib/ramf/serialization.spec.ts
@@ -638,9 +638,8 @@ describe('MessageSerializer', () => {
           StubMessage,
         );
 
-        expect(senderCaCertificateChain).toHaveLength(2);
-        expect(senderCaCertificateChain[0].isEqual(SENDER_CERTIFICATE)).toBeTrue();
-        expect(senderCaCertificateChain[1].isEqual(caCertificate)).toBeTrue();
+        expect(senderCaCertificateChain).toHaveLength(1);
+        expect(senderCaCertificateChain[0].isEqual(caCertificate)).toBeTrue();
       });
     });
 


### PR DESCRIPTION
This was causing this bug: https://github.com/relaycorp/relaynet-internet-gateway/issues/15
