### PR TITLE
fix: Hide PKI.js from the exported API

### DIFF
--- a/src/lib/crypto_wrappers/cms/envelopedData.ts
+++ b/src/lib/crypto_wrappers/cms/envelopedData.ts
@@ -81,7 +81,14 @@ export abstract class EnvelopedData {
     return new envelopedDataClass(pkijsEnvelopedData);
   }
 
-  protected constructor(readonly pkijsEnvelopedData: pkijs.EnvelopedData) {}
+  /**
+   * @internal
+   */
+  public readonly pkijsEnvelopedData: pkijs.EnvelopedData;
+
+  protected constructor(pkijsEnvelopedData: pkijs.EnvelopedData) {
+    this.pkijsEnvelopedData = pkijsEnvelopedData;
+  }
 
   /**
    * Return the DER serialization of the current EnvelopedData value.

--- a/src/lib/crypto_wrappers/x509/Certificate.ts
+++ b/src/lib/crypto_wrappers/x509/Certificate.ts
@@ -111,7 +111,14 @@ export default class Certificate {
     return new Certificate(pkijsCert);
   }
 
-  public constructor(public readonly pkijsCertificate: pkijs.Certificate) {}
+  /**
+   * @internal
+   */
+  public readonly pkijsCertificate: pkijs.Certificate;
+
+  public constructor(pkijsCertificate: pkijs.Certificate) {
+    this.pkijsCertificate = pkijsCertificate;
+  }
 
   /**
    * Serialize certificate as DER-encoded buffer.


### PR DESCRIPTION
Fixes #52

However, the proper, long-term solution should be https://github.com/relaycorp/relayverse/issues/11