### PR TITLE
fix(CMS): Downgrade AES cipher mode from GCM to CBC

### DIFF
--- a/src/lib/_test_utils.ts
+++ b/src/lib/_test_utils.ts
@@ -7,6 +7,12 @@ import { generateRSAKeyPair, getPublicKeyDigestHex } from './crypto_wrappers/key
 import Certificate from './crypto_wrappers/x509/Certificate';
 import FullCertificateIssuanceOptions from './crypto_wrappers/x509/FullCertificateIssuanceOptions';
 
+export const CRYPTO_OIDS = {
+  AES_CBC_128: '2.16.840.1.101.3.4.1.2',
+  AES_CBC_192: '2.16.840.1.101.3.4.1.22',
+  AES_CBC_256: '2.16.840.1.101.3.4.1.42',
+};
+
 type PkijsValueType = pkijs.RelativeDistinguishedNames | pkijs.Certificate;
 
 export function expectPkijsValuesToBeEqual(

--- a/src/lib/crypto_wrappers/cms/envelopedData.spec.ts
+++ b/src/lib/crypto_wrappers/cms/envelopedData.spec.ts
@@ -25,9 +25,9 @@ import {
 } from './envelopedData';
 
 const OID_SHA256 = '2.16.840.1.101.3.4.2.1';
-const OID_AES_GCM_128 = '2.16.840.1.101.3.4.1.6';
-const OID_AES_GCM_192 = '2.16.840.1.101.3.4.1.26';
-const OID_AES_GCM_256 = '2.16.840.1.101.3.4.1.46';
+const OID_AES_CBC_128 = '2.16.840.1.101.3.4.1.2';
+const OID_AES_CBC_192 = '2.16.840.1.101.3.4.1.22';
+const OID_AES_CBC_256 = '2.16.840.1.101.3.4.1.42';
 const OID_RSA_OAEP = '1.2.840.113549.1.1.7';
 const OID_ECDH_P256 = '1.2.840.10045.3.1.7';
 const OID_RELAYNET_ORIGINATOR_EPHEMERAL_CERT_SERIAL_NUMBER = '0.4.0.127.0.17.0.1.0';
@@ -520,19 +520,19 @@ function describeEncryptedContentInfoEncryption(
   encryptFunc: (opts?: EncryptionOptions) => Promise<ArrayBuffer>,
 ): void {
   describe('EncryptedContentInfo', () => {
-    test('AES-GCM-128 should be used by default', async () => {
+    test('AES-CBC-128 should be used by default', async () => {
       const envelopedDataSerialized = await encryptFunc();
 
       const envelopedData = deserializeEnvelopedData(envelopedDataSerialized);
       expect(envelopedData.encryptedContentInfo.contentEncryptionAlgorithm.algorithmId).toEqual(
-        OID_AES_GCM_128,
+        OID_AES_CBC_128,
       );
     });
 
     test.each([
-      [192, OID_AES_GCM_192],
-      [256, OID_AES_GCM_256],
-    ])('AES-GCM-%s should also be supported', async (aesKeySize, expectedOid) => {
+      [192, OID_AES_CBC_192],
+      [256, OID_AES_CBC_256],
+    ])('AES-CBC-%s should also be supported', async (aesKeySize, expectedOid) => {
       const envelopedDataSerialized = await encryptFunc({ aesKeySize: aesKeySize as number });
 
       const envelopedData = deserializeEnvelopedData(envelopedDataSerialized);

--- a/src/lib/crypto_wrappers/cms/envelopedData.spec.ts
+++ b/src/lib/crypto_wrappers/cms/envelopedData.spec.ts
@@ -1,9 +1,10 @@
-// tslint:disable:no-let no-object-mutation
+// tslint:disable:no-object-mutation
 import * as asn1js from 'asn1js';
 import * as pkijs from 'pkijs';
 
 import {
   arrayBufferFrom,
+  CRYPTO_OIDS,
   expectAsn1ValuesToBeEqual,
   expectBuffersToEqual,
   expectPkijsValuesToBeEqual,
@@ -25,9 +26,6 @@ import {
 } from './envelopedData';
 
 const OID_SHA256 = '2.16.840.1.101.3.4.2.1';
-const OID_AES_CBC_128 = '2.16.840.1.101.3.4.1.2';
-const OID_AES_CBC_192 = '2.16.840.1.101.3.4.1.22';
-const OID_AES_CBC_256 = '2.16.840.1.101.3.4.1.42';
 const OID_RSA_OAEP = '1.2.840.113549.1.1.7';
 const OID_ECDH_P256 = '1.2.840.10045.3.1.7';
 const OID_RELAYNET_ORIGINATOR_EPHEMERAL_CERT_SERIAL_NUMBER = '0.4.0.127.0.17.0.1.0';
@@ -525,13 +523,13 @@ function describeEncryptedContentInfoEncryption(
 
       const envelopedData = deserializeEnvelopedData(envelopedDataSerialized);
       expect(envelopedData.encryptedContentInfo.contentEncryptionAlgorithm.algorithmId).toEqual(
-        OID_AES_CBC_128,
+        CRYPTO_OIDS.AES_CBC_128,
       );
     });
 
     test.each([
-      [192, OID_AES_CBC_192],
-      [256, OID_AES_CBC_256],
+      [192, CRYPTO_OIDS.AES_CBC_192],
+      [256, CRYPTO_OIDS.AES_CBC_256],
     ])('AES-CBC-%s should also be supported', async (aesKeySize, expectedOid) => {
       const envelopedDataSerialized = await encryptFunc({ aesKeySize: aesKeySize as number });
 

--- a/src/lib/crypto_wrappers/cms/envelopedData.ts
+++ b/src/lib/crypto_wrappers/cms/envelopedData.ts
@@ -12,6 +12,7 @@ import CMSError from './CMSError';
 
 const pkijsCrypto = getPkijsCrypto();
 
+const AES_CIPHER_MODE = 'AES-CBC';
 const AES_KEY_SIZES: ReadonlyArray<number> = [128, 192, 256];
 
 export interface EncryptionOptions {
@@ -153,8 +154,7 @@ export class SessionlessEnvelopedData extends EnvelopedData {
 
     const aesKeySize = getAesKeySize(options.aesKeySize);
     await pkijsEnvelopedData.encrypt(
-      // @ts-ignore
-      { name: 'AES-GCM', length: aesKeySize },
+      { name: AES_CIPHER_MODE, length: aesKeySize } as any,
       plaintext,
     );
 
@@ -219,7 +219,7 @@ export class SessionEnvelopedData extends EnvelopedData {
     const [pkijsEncryptionResult]: ReadonlyArray<{
       readonly ecdhPrivateKey: CryptoKey;
     }> = (await pkijsEnvelopedData.encrypt(
-      { name: 'AES-GCM', length: aesKeySize } as any,
+      { name: AES_CIPHER_MODE, length: aesKeySize } as any,
       plaintext,
     )) as any;
     const dhPrivateKey = pkijsEncryptionResult.ecdhPrivateKey;

--- a/src/lib/crypto_wrappers/cms/envelopedData.ts
+++ b/src/lib/crypto_wrappers/cms/envelopedData.ts
@@ -12,6 +12,7 @@ import CMSError from './CMSError';
 
 const pkijsCrypto = getPkijsCrypto();
 
+// CBC mode is temporary. See: https://github.com/relaycorp/relayverse/issues/16
 const AES_CIPHER_MODE = 'AES-CBC';
 const AES_KEY_SIZES: ReadonlyArray<number> = [128, 192, 256];
 

--- a/src/lib/nodes/gateway.spec.ts
+++ b/src/lib/nodes/gateway.spec.ts
@@ -1,9 +1,7 @@
-/* tslint:disable:no-let */
-
 import bufferToArray from 'buffer-to-arraybuffer';
 
 import { SignatureOptions } from '../..';
-import { arrayToAsyncIterable, asyncIterableToArray } from '../_test_utils';
+import { arrayToAsyncIterable, asyncIterableToArray, CRYPTO_OIDS } from '../_test_utils';
 import { generateRandom64BitValue } from '../crypto_wrappers/_utils';
 import {
   EnvelopedData,
@@ -172,7 +170,7 @@ describe('Gateway', () => {
       );
 
       expect(await getCargoPayloadEncryptionAlgorithmId(cargoesSerialized[0])).toEqual(
-        '2.16.840.1.101.3.4.1.26',
+        CRYPTO_OIDS.AES_CBC_192,
       );
     });
 
@@ -190,7 +188,7 @@ describe('Gateway', () => {
       );
 
       expect(await getCargoPayloadEncryptionAlgorithmId(cargoesSerialized[0])).toEqual(
-        '2.16.840.1.101.3.4.1.26',
+        CRYPTO_OIDS.AES_CBC_192,
       );
     });
 


### PR DESCRIPTION
Fixes https://github.com/relaycorp/relaynet-internet-gateway/issues/204

See also: https://github.com/relaycorp/relayverse/issues/16
