### PR TITLE
fix: Resolve inconsistencies with the Channel Session Protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11870,9 +11870,8 @@
       }
     },
     "pkijs": {
-      "version": "2.1.96",
-      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-2.1.96.tgz",
-      "integrity": "sha512-/me12INSijogZfRYbuBRTeLpxHVMHAmSsaYvuSeieK0PVep8+0yOjBFz05jv6zfEg1vQm0kX7Cm1uYEXM5wUfg==",
+      "version": "github:gnarea/PKI.js#9e6e510d951b7b718d0df14a694aeaffc02a41c0",
+      "from": "github:gnarea/PKI.js#EnvelopedData-RecipientKeyIdentifier-generated-v1",
       "requires": {
         "asn1js": "^2.1.1",
         "bytestreamjs": "^1.0.29",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "buffer-to-arraybuffer": "0.0.6",
     "dohdec": "^3.1.0",
     "moment": "^2.29.1",
-    "pkijs": "^2.1.96",
+    "pkijs": "github:gnarea/PKI.js#EnvelopedData-RecipientKeyIdentifier-generated-v1",
     "smart-buffer": "^4.1.0",
     "uuid4": "^2.0.2",
     "verror": "^1.10.0"


### PR DESCRIPTION
This was blocked by https://github.com/PeculiarVentures/PKI.js/issues/304

This work is part of https://github.com/relaycorp/relayverse/issues/27