### PR TITLE
chore: Move Jest config for integration tests into test directory

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,8 @@
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
+const path = require('path');
+
 module.exports = {
   // All imported modules in your tests should be mocked automatically
   // automock: false,
@@ -122,7 +124,7 @@ module.exports = {
   setupFiles: ["jest-date-mock"],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  setupFilesAfterEnv: ["jest-extended", "./jest.setup.js"],
+  setupFilesAfterEnv: ["jest-extended", path.join(__dirname, "jest.setup.js")],
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
   // snapshotSerializers: [],

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "static-checks:prettier": "prettier \"src/**/*.ts\" --list-different",
     "test:ci:unit": "run-s build test:ci:unit:jest",
     "test:ci:unit:jest": "jest --config jest.config.ci.js --coverage",
-    "test:integration": "jest --config jest.config.integration.js",
+    "test:integration": "jest --config src/integration_tests/jest.config.js",
     "cov": "run-s build test:unit && opn coverage/lcov-report/index.html",
     "doc-api": "typedoc src/index.ts --out build/docs/api",
     "clean": "del-cli build test"

--- a/src/integration_tests/jest.config.js
+++ b/src/integration_tests/jest.config.js
@@ -1,8 +1,8 @@
-const mainJestConfig = require('./jest.config');
+const mainJestConfig = require('../../jest.config');
 
 module.exports = {
   preset: mainJestConfig.preset,
-  roots: ['src/integration_tests'],
+  roots: ['.'],
   testEnvironment: mainJestConfig.testEnvironment,
   setupFilesAfterEnv: mainJestConfig.setupFilesAfterEnv
 };


### PR DESCRIPTION
To make it possible for WebStorm to find the right config when running individual tests.