### PR TITLE
fix(deps): Replace PKI.js fork with latest release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11948,8 +11948,9 @@
       }
     },
     "pkijs": {
-      "version": "github:gnarea/PKI.js#98c14d15916068a5dd5700606da5811915d8d609",
-      "from": "github:gnarea/PKI.js#EnvelopedData-RecipientKeyIdentifier-generated-v4",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-2.2.1.tgz",
+      "integrity": "sha512-EzMnN5uwMPggjhQap+MeMG7pSc/1zQcc7GxW+NjJ2RLXgyoxpm7CakELlHtLK5KwKdiMpC6FtbYd13MNY88x6g==",
       "requires": {
         "asn1js": "^2.1.1",
         "bytestreamjs": "^1.0.29",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "dohdec": "^3.1.0",
     "is-valid-domain": "^0.1.2",
     "moment": "^2.29.1",
-    "pkijs": "github:gnarea/PKI.js#EnvelopedData-RecipientKeyIdentifier-generated-v4",
+    "pkijs": "^2.2.1",
     "smart-buffer": "^4.2.0",
     "uuid4": "^2.0.2",
     "verror": "^1.10.0"


### PR DESCRIPTION
PeculiarVentures/PKI.js#333 and PeculiarVentures/PKI.js#336 have now been released.
