### PR TITLE
feat: Move certificate storage from PrivateKeyStore to new CertificateStore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3520,6 +3520,12 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.26.0.tgz",
+      "integrity": "sha512-VQI812dRi3cusdY/fhoBKvc6l2W8BPWU1FNVnFH9Nttjx4AFBRzfSVb/Eyc7jBT6e9sg1XtAGsYpBQ6c/jygbg==",
+      "dev": true
+    },
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/binary-parser": "^1.5.1",
     "@types/jest": "^27.0.2",
     "@types/pkijs": "0.0.12",
+    "date-fns": "^2.26.0",
     "del-cli": "^4.0.1",
     "jest": "^26.6.3",
     "jest-date-mock": "^1.0.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,3 +88,5 @@ export { EndpointManager } from './lib/nodes/EndpointManager';
 export { PublicNodeConnectionParams } from './lib/nodes/PublicNodeConnectionParams';
 export * from './lib/nodes/errors';
 export * from './lib/publicAddressing';
+export { MockCertificateStore } from './lib/keyStores/CertificateStore.spec';
+export { MockStoredCertificateData } from './lib/keyStores/CertificateStore.spec';

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,5 +88,3 @@ export { EndpointManager } from './lib/nodes/EndpointManager';
 export { PublicNodeConnectionParams } from './lib/nodes/PublicNodeConnectionParams';
 export * from './lib/nodes/errors';
 export * from './lib/publicAddressing';
-export { MockCertificateStore } from './lib/keyStores/CertificateStore.spec';
-export { MockStoredCertificateData } from './lib/keyStores/CertificateStore.spec';

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export {
 } from './lib/crypto_wrappers/keys';
 export * from './lib/keyStores/privateKeyStore';
 export * from './lib/keyStores/publicKeyStore';
+export { CertificateStore } from './lib/keyStores/CertificateStore';
 export * from './lib/keyStores/testMocks';
 export { default as PublicKeyStoreError } from './lib/keyStores/PublicKeyStoreError';
 export { default as UnknownKeyError } from './lib/keyStores/UnknownKeyError';

--- a/src/lib/keyStores/CertificateStore.spec.ts
+++ b/src/lib/keyStores/CertificateStore.spec.ts
@@ -1,14 +1,41 @@
-import { MockCertificateStore } from './testMocks';
+import { addSeconds, subSeconds } from 'date-fns';
+
+import { generateRSAKeyPair } from '../crypto_wrappers/keys';
+import Certificate from '../crypto_wrappers/x509/Certificate';
+import { issueGatewayCertificate } from '../pki';
+import { MockCertificateStore, MockStoredCertificateData } from './testMocks';
 
 const store = new MockCertificateStore();
 beforeEach(() => {
   store.clear();
 });
 
-describe('save', () => {
-  test.todo('Expired certificate should not be saved');
+let keyPair: CryptoKeyPair;
+beforeAll(async () => {
+  keyPair = await generateRSAKeyPair();
+});
 
-  test.todo('Valid certificate should be saved');
+describe('save', () => {
+  test('Expired certificate should not be saved', async () => {
+    const certificate = await generateCertificate(subSeconds(new Date(), 1));
+
+    await store.save(certificate);
+
+    expect(store.dataByPrivateAddress).toBeEmpty();
+  });
+
+  test('Valid certificate should be saved', async () => {
+    const expiryDate = addSeconds(new Date(), 2);
+    const certificate = await generateCertificate(expiryDate);
+
+    await store.save(certificate);
+
+    expect(store.dataByPrivateAddress).not.toBeEmpty();
+    expect(store.dataByPrivateAddress).toHaveProperty<readonly MockStoredCertificateData[]>(
+      await certificate.calculateSubjectPrivateAddress(),
+      [{ expiryDate, certificateSerialized: certificate.serialize() }],
+    );
+  });
 });
 
 describe('retrieveLatest', () => {
@@ -30,3 +57,12 @@ describe('retrieveAll', () => {
 describe('deleteExpired', () => {
   test.todo('Backend should be instructed to delete expired certificates');
 });
+
+async function generateCertificate(validityEndDate: Date): Promise<Certificate> {
+  return issueGatewayCertificate({
+    issuerPrivateKey: keyPair.privateKey,
+    subjectPublicKey: keyPair.publicKey,
+    validityEndDate,
+    validityStartDate: subSeconds(validityEndDate, 1),
+  });
+}

--- a/src/lib/keyStores/CertificateStore.spec.ts
+++ b/src/lib/keyStores/CertificateStore.spec.ts
@@ -119,7 +119,7 @@ describe('retrieveLatest', () => {
   });
 
   test('Valid certificate should be returned', async () => {
-    const certificate = await generateCertificate(addSeconds(new Date(), 1));
+    const certificate = await generateCertificate(addSeconds(new Date(), 2));
     await store.save(certificate);
 
     const retrievedCertificate = await store.retrieveLatest(privateAddress);

--- a/src/lib/keyStores/CertificateStore.spec.ts
+++ b/src/lib/keyStores/CertificateStore.spec.ts
@@ -134,7 +134,7 @@ describe('retrieveAll', () => {
   });
 
   test('Expired certificates should be ignored', async () => {
-    const validCertificate = await generateCertificate(addSeconds(new Date(), 1));
+    const validCertificate = await generateCertificate(addSeconds(new Date(), 2));
     await store.save(validCertificate);
     const expiredCertificate = await generateCertificate(subSeconds(new Date(), 1));
     await store.forceSave(expiredCertificate);
@@ -146,7 +146,7 @@ describe('retrieveAll', () => {
   });
 
   test('Valid certificates should be returned', async () => {
-    const certificate1 = await generateCertificate(addSeconds(new Date(), 1));
+    const certificate1 = await generateCertificate(addSeconds(new Date(), 2));
     await store.save(certificate1);
     const certificate2 = await generateCertificate(addSeconds(new Date(), 5));
     await store.save(certificate2);

--- a/src/lib/keyStores/CertificateStore.spec.ts
+++ b/src/lib/keyStores/CertificateStore.spec.ts
@@ -1,0 +1,32 @@
+import { MockCertificateStore } from './testMocks';
+
+const store = new MockCertificateStore();
+beforeEach(() => {
+  store.clear();
+});
+
+describe('save', () => {
+  test.todo('Expired certificate should not be saved');
+
+  test.todo('Valid certificate should be saved');
+});
+
+describe('retrieveLatest', () => {
+  test.todo('Nothing should be returned if certificate does not exist');
+
+  test.todo('Expired certificate should be ignored');
+
+  test.todo('Valid certificate should be returned');
+});
+
+describe('retrieveAll', () => {
+  test.todo('Nothing should be returned if no certificate exists');
+
+  test.todo('Expired certificates should be ignored');
+
+  test.todo('Valid certificates should be returned');
+});
+
+describe('deleteExpired', () => {
+  test.todo('Backend should be instructed to delete expired certificates');
+});

--- a/src/lib/keyStores/CertificateStore.spec.ts
+++ b/src/lib/keyStores/CertificateStore.spec.ts
@@ -63,11 +63,34 @@ describe('retrieveLatest', () => {
 });
 
 describe('retrieveAll', () => {
-  test.todo('Nothing should be returned if no certificate exists');
+  test('Nothing should be returned if no certificate exists', async () => {
+    await expect(store.retrieveAll(privateAddress)).resolves.toBeEmpty();
+  });
 
-  test.todo('Expired certificates should be ignored');
+  test('Expired certificates should be ignored', async () => {
+    const validCertificate = await generateCertificate(addSeconds(new Date(), 1));
+    await store.save(validCertificate);
+    const expiredCertificate = await generateCertificate(subSeconds(new Date(), 1));
+    await store.forceSave(expiredCertificate);
 
-  test.todo('Valid certificates should be returned');
+    const allCertificates = await store.retrieveAll(privateAddress);
+
+    expect(allCertificates).toHaveLength(1);
+    expect(validCertificate.isEqual(allCertificates[0])).toBeTrue();
+  });
+
+  test('Valid certificates should be returned', async () => {
+    const certificate1 = await generateCertificate(addSeconds(new Date(), 1));
+    await store.save(certificate1);
+    const certificate2 = await generateCertificate(addSeconds(new Date(), 5));
+    await store.save(certificate2);
+
+    const allCertificates = await store.retrieveAll(privateAddress);
+
+    expect(allCertificates).toHaveLength(2);
+    expect(allCertificates.filter((c) => certificate1.isEqual(c))).toHaveLength(1);
+    expect(allCertificates.filter((c) => certificate2.isEqual(c))).toHaveLength(1);
+  });
 });
 
 describe('deleteExpired', () => {

--- a/src/lib/keyStores/CertificateStore.ts
+++ b/src/lib/keyStores/CertificateStore.ts
@@ -19,8 +19,13 @@ export abstract class CertificateStore {
     }
   }
 
-  public async retrieveLatest(subjectPrivateAddress: string): Promise<Certificate> {
-    throw new Error('implement' + subjectPrivateAddress);
+  public async retrieveLatest(subjectPrivateAddress: string): Promise<Certificate | null> {
+    const serialization = await this.retrieveLatestSerialization(subjectPrivateAddress);
+    if (!serialization) {
+      return null;
+    }
+    const certificate = Certificate.deserialize(serialization);
+    return new Date() < certificate.expiryDate ? certificate : null;
   }
 
   public async retrieveAll(subjectPrivateAddress: string): Promise<readonly Certificate[]> {

--- a/src/lib/keyStores/CertificateStore.ts
+++ b/src/lib/keyStores/CertificateStore.ts
@@ -35,9 +35,7 @@ export abstract class CertificateStore {
       .filter((c) => new Date() < c.expiryDate);
   }
 
-  public async deleteExpired(): Promise<void> {
-    throw new Error('implement');
-  }
+  public abstract deleteExpired(): Promise<void>;
 
   protected abstract saveData(
     subjectPrivateAddress: string,
@@ -52,6 +50,4 @@ export abstract class CertificateStore {
   protected abstract retrieveAllSerializations(
     subjectPrivateAddress: string,
   ): Promise<readonly ArrayBuffer[]>;
-
-  protected abstract deleteExpiredData(): Promise<void>;
 }

--- a/src/lib/keyStores/CertificateStore.ts
+++ b/src/lib/keyStores/CertificateStore.ts
@@ -1,0 +1,35 @@
+import Certificate from '../crypto_wrappers/x509/Certificate';
+
+export abstract class CertificateStore {
+  public async save(certificate: Certificate): Promise<void> {
+    throw new Error('implement' + certificate);
+  }
+
+  public async retrieveLatest(subjectPrivateAddress: string): Promise<Certificate> {
+    throw new Error('implement' + subjectPrivateAddress);
+  }
+
+  public async retrieveAll(subjectPrivateAddress: string): Promise<readonly Certificate[]> {
+    throw new Error('implement' + subjectPrivateAddress);
+  }
+
+  public async deleteExpired(): Promise<void> {
+    throw new Error('implement');
+  }
+
+  protected abstract saveData(
+    subjectPrivateAddress: string,
+    subjectCertificateSerialized: ArrayBuffer,
+    subjectCertificateExpiryDate: Date,
+  ): Promise<void>;
+
+  protected abstract retrieveLatestSerialization(
+    subjectPrivateAddress: string,
+  ): Promise<ArrayBuffer | null>;
+
+  protected abstract retrieveAllSerializations(
+    subjectPrivateAddress: string,
+  ): Promise<readonly ArrayBuffer[]>;
+
+  protected abstract deleteExpiredData(): Promise<void>;
+}

--- a/src/lib/keyStores/CertificateStore.ts
+++ b/src/lib/keyStores/CertificateStore.ts
@@ -29,7 +29,10 @@ export abstract class CertificateStore {
   }
 
   public async retrieveAll(subjectPrivateAddress: string): Promise<readonly Certificate[]> {
-    throw new Error('implement' + subjectPrivateAddress);
+    const allCertificatesSerialized = await this.retrieveAllSerializations(subjectPrivateAddress);
+    return allCertificatesSerialized
+      .map((s) => Certificate.deserialize(s))
+      .filter((c) => new Date() < c.expiryDate);
   }
 
   public async deleteExpired(): Promise<void> {

--- a/src/lib/keyStores/CertificateStore.ts
+++ b/src/lib/keyStores/CertificateStore.ts
@@ -1,8 +1,22 @@
 import Certificate from '../crypto_wrappers/x509/Certificate';
 
+/**
+ * Store of certificates.
+ */
 export abstract class CertificateStore {
+  /**
+   * Store `certificate` as long as it's still valid.
+   *
+   * @param certificate
+   */
   public async save(certificate: Certificate): Promise<void> {
-    throw new Error('implement' + certificate);
+    if (new Date() < certificate.expiryDate) {
+      await this.saveData(
+        await certificate.calculateSubjectPrivateAddress(),
+        certificate.serialize(),
+        certificate.expiryDate,
+      );
+    }
   }
 
   public async retrieveLatest(subjectPrivateAddress: string): Promise<Certificate> {

--- a/src/lib/keyStores/testMocks.ts
+++ b/src/lib/keyStores/testMocks.ts
@@ -101,7 +101,7 @@ export interface MockStoredCertificateData {
 }
 
 export class MockCertificateStore extends CertificateStore {
-  public certificateDataByPrivateAddress: {
+  public dataByPrivateAddress: {
     // tslint:disable-next-line:readonly-array
     [privateAddress: string]: MockStoredCertificateData[];
   } = {};
@@ -109,7 +109,7 @@ export class MockCertificateStore extends CertificateStore {
   public expiredCertificatesDeleted: boolean = false;
 
   public clear(): void {
-    this.certificateDataByPrivateAddress = {};
+    this.dataByPrivateAddress = {};
     this.expiredCertificatesDeleted = false;
   }
 
@@ -120,7 +120,7 @@ export class MockCertificateStore extends CertificateStore {
   protected async retrieveAllSerializations(
     subjectPrivateAddress: string,
   ): Promise<readonly ArrayBuffer[]> {
-    const certificateData = this.certificateDataByPrivateAddress[subjectPrivateAddress];
+    const certificateData = this.dataByPrivateAddress[subjectPrivateAddress];
     if (!certificateData) {
       return [];
     }
@@ -130,7 +130,7 @@ export class MockCertificateStore extends CertificateStore {
   protected async retrieveLatestSerialization(
     subjectPrivateAddress: string,
   ): Promise<ArrayBuffer | null> {
-    const certificateData = this.certificateDataByPrivateAddress[subjectPrivateAddress] ?? [];
+    const certificateData = this.dataByPrivateAddress[subjectPrivateAddress] ?? [];
     if (certificateData.length === 0) {
       return null;
     }
@@ -149,11 +149,7 @@ export class MockCertificateStore extends CertificateStore {
       certificateSerialized: subjectCertificateSerialized,
       expiryDate: subjectCertificateExpiryDate,
     };
-    const originalCertificateData =
-      this.certificateDataByPrivateAddress[subjectPrivateAddress] ?? [];
-    this.certificateDataByPrivateAddress[subjectPrivateAddress] = [
-      ...originalCertificateData,
-      mockData,
-    ];
+    const originalCertificateData = this.dataByPrivateAddress[subjectPrivateAddress] ?? [];
+    this.dataByPrivateAddress[subjectPrivateAddress] = [...originalCertificateData, mockData];
   }
 }

--- a/src/lib/keyStores/testMocks.ts
+++ b/src/lib/keyStores/testMocks.ts
@@ -113,6 +113,14 @@ export class MockCertificateStore extends CertificateStore {
     this.expiredCertificatesDeleted = false;
   }
 
+  public async forceSave(certificate: Certificate): Promise<void> {
+    await this.saveData(
+      await certificate.calculateSubjectPrivateAddress(),
+      certificate.serialize(),
+      certificate.expiryDate,
+    );
+  }
+
   protected async deleteExpiredData(): Promise<void> {
     this.expiredCertificatesDeleted = true;
   }

--- a/src/lib/keyStores/testMocks.ts
+++ b/src/lib/keyStores/testMocks.ts
@@ -1,62 +1,60 @@
 // tslint:disable:max-classes-per-file no-object-mutation readonly-keyword
 
-import { derSerializePrivateKey } from '../crypto_wrappers/keys';
-import Certificate from '../crypto_wrappers/x509/Certificate';
-import { PrivateKeyData, PrivateKeyStore } from './privateKeyStore';
+import { PrivateKeyStore, SessionPrivateKeyData } from './privateKeyStore';
 import { PublicKeyStore, SessionPublicKeyData } from './publicKeyStore';
 
 export class MockPrivateKeyStore extends PrivateKeyStore {
-  // tslint:disable-next-line:readonly-keyword
-  public keys: { [key: string]: PrivateKeyData } = {};
+  public identityKeys: { [privateAddress: string]: Buffer } = {};
+
+  public sessionKeys: { [keyId: string]: SessionPrivateKeyData } = {};
 
   constructor(protected readonly failOnSave = false, protected readonly failOnFetch = false) {
     super();
   }
 
   public clear(): void {
-    this.keys = {};
+    this.identityKeys = {};
+    this.sessionKeys = {};
   }
 
-  public async registerNodeKey(privateKey: CryptoKey, certificate: Certificate): Promise<void> {
-    // tslint:disable-next-line:no-object-mutation
-    this.keys[certificate.getSerialNumberHex()] = {
-      certificateDer: Buffer.from(certificate.serialize()),
-      keyDer: await derSerializePrivateKey(privateKey),
-      type: 'node',
-    };
-  }
-
-  public async registerInitialSessionKey(privateKey: CryptoKey, keyId: Buffer): Promise<void> {
-    this.keys[keyId.toString('hex')] = {
-      keyDer: await derSerializePrivateKey(privateKey),
-      type: 'session-initial',
-    };
-  }
-
-  public async registerSubsequentSessionKey(
-    privateKey: CryptoKey,
-    keyId: string,
-    peerPrivateAddress: string,
-  ): Promise<void> {
-    this.keys[keyId] = {
-      keyDer: await derSerializePrivateKey(privateKey),
-      peerPrivateAddress,
-      type: 'session-subsequent',
-    };
-  }
-
-  protected async fetchKey(keyId: string): Promise<PrivateKeyData | null> {
+  protected async retrieveIdentityKeySerialized(privateAddress: string): Promise<Buffer | null> {
     if (this.failOnFetch) {
       throw new Error('Denied');
     }
-    return this.keys[keyId] ?? null;
+    return this.identityKeys[privateAddress];
   }
 
-  protected async saveKey(privateKeyData: PrivateKeyData, keyId: string): Promise<void> {
+  protected async saveIdentityKeySerialized(
+    privateAddress: string,
+    keySerialized: Buffer,
+  ): Promise<void> {
     if (this.failOnSave) {
       throw new Error('Denied');
     }
-    this.keys[keyId] = privateKeyData;
+    this.identityKeys[privateAddress] = keySerialized;
+  }
+
+  protected async saveSessionKeySerialized(
+    keyId: string,
+    keySerialized: Buffer,
+    peerPrivateAddress?: string,
+  ): Promise<void> {
+    if (this.failOnSave) {
+      throw new Error('Denied');
+    }
+
+    this.sessionKeys[keyId] = {
+      keySerialized,
+      peerPrivateAddress,
+    };
+  }
+
+  protected async retrieveSessionKeyData(keyId: string): Promise<SessionPrivateKeyData | null> {
+    if (this.failOnFetch) {
+      throw new Error('Denied');
+    }
+
+    return this.sessionKeys[keyId] ?? null;
   }
 }
 


### PR DESCRIPTION
To help implement https://github.com/relaycorp/relaynet-internet-gateway/issues/49 and https://github.com/relaycorp/relaynet-pong/issues/26

Fixes #55.

TODO

- [x] Remove certs from private key store.