### PR TITLE
fix(deps): Remove dependency on binary-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2313,15 +2313,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/binary-parser": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/binary-parser/-/binary-parser-1.5.1.tgz",
-      "integrity": "sha512-wxSg5YQFVYsyGwuCSTdBu+cUIYCD9eX0pq3CsJbP4DLeLExbwEPqci9JgjCNHv1ZfLO/QzVtGlasec5xSUcCVA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/graceful-fs": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
@@ -2940,11 +2931,6 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
       "dev": true
-    },
-    "binary-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/binary-parser/-/binary-parser-2.0.1.tgz",
-      "integrity": "sha512-7kZx8vZCq+V/0XkaOjLpCkBdOYCzjau+yt1PDMM04Q73WgtNYSoM6gOpl/Ky7qbANrEkcbX9ya+6Fdmj1WeU+w=="
     },
     "bottleneck": {
       "version": "2.19.5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@stablelib/aes-kw": "^1.0.1",
     "@types/verror": "^1.10.5",
     "asn1js": "^2.1.1",
-    "binary-parser": "^2.0.1",
     "buffer-to-arraybuffer": "0.0.6",
     "dohdec": "^3.1.0",
     "is-valid-domain": "^0.1.4",
@@ -58,7 +57,6 @@
   "devDependencies": {
     "@relaycorp/shared-config": "^1.6.0",
     "@types/asn1js": "2.0.2",
-    "@types/binary-parser": "^1.5.1",
     "@types/jest": "^27.0.3",
     "@types/pkijs": "0.0.12",
     "date-fns": "^2.26.0",

--- a/src/lib/ramf/serialization.spec.ts
+++ b/src/lib/ramf/serialization.spec.ts
@@ -454,9 +454,10 @@ describe('MessageSerializer', () => {
           stubConcreteMessageVersionOctet,
           StubMessage,
         ),
-      ).rejects.toMatchObject<Partial<RAMFSyntaxError>>({
-        message: expect.stringMatching(/^Serialization starts with invalid RAMF format signature/),
-      });
+      ).rejects.toThrowWithMessage(
+        RAMFSyntaxError,
+        'RAMF format signature does not begin with "Relaynet"',
+      );
     });
 
     test('Messages larger than 9 MiB should be refused', async () => {

--- a/src/lib/ramf/serialization.spec.ts
+++ b/src/lib/ramf/serialization.spec.ts
@@ -477,7 +477,7 @@ describe('MessageSerializer', () => {
 
     describe('Format signature', () => {
       test('Input should be long enough to contain format signature', async () => {
-        const serialization = bufferToArray(Buffer.from('Relay'));
+        const serialization = bufferToArray(Buffer.from('a'.repeat(9)));
         await expect(
           deserialize(
             serialization,
@@ -485,10 +485,9 @@ describe('MessageSerializer', () => {
             stubConcreteMessageVersionOctet,
             StubMessage,
           ),
-        ).rejects.toEqual(
-          new RAMFSyntaxError(
-            'Serialization starts with invalid RAMF format signature: Relaynet is not defined',
-          ),
+        ).rejects.toThrowWithMessage(
+          RAMFSyntaxError,
+          'Serialization is too small to contain RAMF format signature',
         );
       });
 
@@ -501,10 +500,9 @@ describe('MessageSerializer', () => {
             stubConcreteMessageVersionOctet,
             StubMessage,
           ),
-        ).rejects.toEqual(
-          new RAMFSyntaxError(
-            'Serialization starts with invalid RAMF format signature: Relaynet is not defined',
-          ),
+        ).rejects.toThrowWithMessage(
+          RAMFSyntaxError,
+          'RAMF format signature does not begin with "Relaynet"',
         );
       });
 
@@ -524,7 +522,10 @@ describe('MessageSerializer', () => {
             stubConcreteMessageVersionOctet,
             StubMessage,
           ),
-        ).rejects.toEqual(new RAMFSyntaxError('Expected concrete message type 0x44 but got 0x45'));
+        ).rejects.toThrowWithMessage(
+          RAMFSyntaxError,
+          'Expected concrete message type 0x44 but got 0x45',
+        );
       });
 
       test('A non-matching concrete message version should be refused', async () => {
@@ -543,7 +544,10 @@ describe('MessageSerializer', () => {
             stubConcreteMessageVersionOctet,
             StubMessage,
           ),
-        ).rejects.toEqual(new RAMFSyntaxError('Expected concrete message version 0x2 but got 0x3'));
+        ).rejects.toThrowWithMessage(
+          RAMFSyntaxError,
+          'Expected concrete message version 0x2 but got 0x3',
+        );
       });
     });
 


### PR DESCRIPTION
Because (1) we barely use it these days and (2) their latest "patch" release contained breaking changes.
