### PR TITLE
fix(MockPrivateKeyStore): Make `saveIdentityKey` public

### DIFF
--- a/src/lib/keyStores/testMocks.ts
+++ b/src/lib/keyStores/testMocks.ts
@@ -24,7 +24,7 @@ export class MockPrivateKeyStore extends PrivateKeyStore {
     return this.identityKeys[privateAddress] ?? null;
   }
 
-  protected async saveIdentityKey(privateAddress: string, privateKey: CryptoKey): Promise<void> {
+  public async saveIdentityKey(privateAddress: string, privateKey: CryptoKey): Promise<void> {
     if (this.failOnSave) {
       throw new Error('Denied');
     }


### PR DESCRIPTION
So that it can be used in https://github.com/relaycorp/relaynet-internet-gateway/pull/770
