### PR TITLE
feat: Allow private key stores to override the PKI.js engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,9 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "webcrypto-core": "< 2"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "verror": "^1.10.1",
     "webcrypto-core": "^1.7.5"
   },
+  "peerDependencies": {
+    "webcrypto-core": "< 2"
+  },
   "devDependencies": {
     "@relaycorp/shared-config": "^1.8.0",
     "@types/jest": "^27.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export {
   getPrivateAddressFromIdentityKey,
   RSAKeyGenOptions,
 } from './lib/crypto_wrappers/keys';
+export { PrivateKey } from './lib/crypto_wrappers/PrivateKey';
 export { ECDHCurveName } from './lib/crypto_wrappers/algorithms';
 export { IdentityKeyPair } from './lib/IdentityKeyPair';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ const cryptoEngine = new CryptoEngine({
   name: 'nodeEngine',
   subtle: crypto.subtle,
 });
-setEngine('nodeEngine', crypto, cryptoEngine);
+setEngine('nodeEngine', cryptoEngine);
 //endregion
 
 //region Exports

--- a/src/lib/crypto_wrappers/PrivateKey.spec.ts
+++ b/src/lib/crypto_wrappers/PrivateKey.spec.ts
@@ -1,0 +1,19 @@
+import { Crypto } from '@peculiar/webcrypto';
+
+import { PrivateKey } from './PrivateKey';
+
+describe('constructor', () => {
+  const CRYPTO = new Crypto();
+
+  test('Key type should be private', () => {
+    const key = new PrivateKey(CRYPTO);
+
+    expect(key.type).toEqual('private');
+  });
+
+  test('Crypto should be honoured', () => {
+    const key = new PrivateKey(CRYPTO);
+
+    expect(key.crypto).toEqual(CRYPTO);
+  });
+});

--- a/src/lib/crypto_wrappers/PrivateKey.ts
+++ b/src/lib/crypto_wrappers/PrivateKey.ts
@@ -1,0 +1,9 @@
+import { CryptoKey } from 'webcrypto-core';
+
+export class PrivateKey extends CryptoKey {
+  constructor(public readonly crypto: Crypto) {
+    super();
+
+    this.type = 'private';
+  }
+}

--- a/src/lib/crypto_wrappers/_utils.ts
+++ b/src/lib/crypto_wrappers/_utils.ts
@@ -1,12 +1,21 @@
 import * as asn1js from 'asn1js';
-import * as pkijs from 'pkijs';
+import { CryptoEngine, getCrypto } from 'pkijs';
+
+import { PrivateKey } from './PrivateKey';
 
 export function getPkijsCrypto(): SubtleCrypto {
-  const cryptoEngine = pkijs.getCrypto();
+  const cryptoEngine = getCrypto();
   if (!cryptoEngine) {
     throw new Error('PKI.js crypto engine is undefined');
   }
   return cryptoEngine;
+}
+
+export function getEngineFromPrivateKey(key: CryptoKey | PrivateKey): CryptoEngine | undefined {
+  if (key instanceof PrivateKey) {
+    return new CryptoEngine({ crypto: key.crypto });
+  }
+  return undefined;
 }
 
 export function derDeserialize(derValue: ArrayBuffer): asn1js.AsnType {

--- a/src/lib/crypto_wrappers/cms/signedData.spec.ts
+++ b/src/lib/crypto_wrappers/cms/signedData.spec.ts
@@ -1,5 +1,7 @@
 // tslint:disable:no-object-mutation
 
+import { Crypto } from '@peculiar/webcrypto';
+
 import * as asn1js from 'asn1js';
 import * as pkijs from 'pkijs';
 
@@ -15,6 +17,7 @@ import {
 import { CMS_OIDS } from '../../oids';
 import { HashingAlgorithm } from '../algorithms';
 import { generateRSAKeyPair } from '../keys';
+import { PrivateKey } from '../PrivateKey';
 import Certificate from '../x509/Certificate';
 import { deserializeContentInfo, serializeContentInfo } from './_test_utils';
 import CMSError from './CMSError';
@@ -41,6 +44,19 @@ describe('sign', () => {
     const signedData = await SignedData.sign(plaintext, keyPair.privateKey, certificate);
 
     expect(signedData.pkijsSignedData).toHaveProperty('version', 1);
+  });
+
+  test('Crypto in private key should be used if set', async () => {
+    const crypto = new Crypto();
+    const privateKey = new PrivateKey(crypto);
+    const signSpy = jest.spyOn(crypto.subtle, 'sign');
+    privateKey.algorithm = keyPair.privateKey.algorithm;
+    privateKey.usages = keyPair.privateKey.usages;
+    privateKey.extractable = keyPair.privateKey.extractable;
+
+    await expect(SignedData.sign(plaintext, privateKey, certificate)).toReject();
+
+    expect(signSpy).toBeCalled();
   });
 
   describe('SignerInfo', () => {

--- a/src/lib/crypto_wrappers/cms/signedData.ts
+++ b/src/lib/crypto_wrappers/cms/signedData.ts
@@ -3,8 +3,9 @@
 import * as asn1js from 'asn1js';
 import bufferToArray from 'buffer-to-arraybuffer';
 import * as pkijs from 'pkijs';
+
 import { CMS_OIDS } from '../../oids';
-import { getPkijsCrypto } from '../_utils';
+import { getPkijsCrypto, getEngineFromPrivateKey } from '../_utils';
 import Certificate from '../x509/Certificate';
 import { deserializeContentInfo } from './_utils';
 import CMSError from './CMSError';
@@ -99,6 +100,7 @@ export class SignedData {
       0,
       hashingAlgorithmName,
       encapsulatePlaintext ? undefined : plaintext,
+      getEngineFromPrivateKey(privateKey),
     );
 
     return SignedData.reDeserialize(pkijsSignedData);

--- a/src/lib/crypto_wrappers/x509/Certificate.spec.ts
+++ b/src/lib/crypto_wrappers/x509/Certificate.spec.ts
@@ -112,9 +112,8 @@ describe('issue()', () => {
   test('should use crypto engine in private key if set', async () => {
     const crypto = new Crypto();
     const privateKey = new PrivateKey(crypto);
+    // tslint:disable-next-line:no-object-mutation
     privateKey.algorithm = subjectKeyPair.privateKey.algorithm;
-    privateKey.usages = subjectKeyPair.privateKey.usages;
-    privateKey.extractable = subjectKeyPair.privateKey.extractable;
     jest.spyOn(pkijs.Certificate.prototype, 'sign');
 
     await expect(

--- a/src/lib/crypto_wrappers/x509/Certificate.ts
+++ b/src/lib/crypto_wrappers/x509/Certificate.ts
@@ -3,7 +3,7 @@ import { min, setMilliseconds } from 'date-fns';
 import * as pkijs from 'pkijs';
 
 import * as oids from '../../oids';
-import { derDeserialize, generateRandom64BitValue } from '../_utils';
+import { derDeserialize, generateRandom64BitValue, getEngineFromPrivateKey } from '../_utils';
 import { getPrivateAddressFromIdentityKey, getPublicKeyDigest } from '../keys';
 import CertificateError from './CertificateError';
 import FullCertificateIssuanceOptions from './FullCertificateIssuanceOptions';
@@ -109,7 +109,8 @@ export default class Certificate {
 
     const signatureHashAlgo = (options.issuerPrivateKey.algorithm as RsaHashedKeyGenParams)
       .hash as Algorithm;
-    await pkijsCert.sign(options.issuerPrivateKey, signatureHashAlgo.name);
+    const engine = getEngineFromPrivateKey(options.issuerPrivateKey);
+    await pkijsCert.sign(options.issuerPrivateKey, signatureHashAlgo.name, engine);
     return new Certificate(pkijsCert);
   }
 


### PR DESCRIPTION
But only support identity keys -- that is, `SignedData` and `Certificate`, not `EnvelopedData`.

Needed in https://github.com/relaycorp/awala-keystore-cloud-js/pull/35