### PR TITLE
fix(RAMF): Require private address and support public address of recipient

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,6 @@ export { default as RAMFError } from './lib/ramf/RAMFError';
 export { default as RAMFSyntaxError } from './lib/ramf/RAMFSyntaxError';
 export { MAX_RAMF_MESSAGE_LENGTH } from './lib/ramf/serialization';
 export { default as RAMFMessage } from './lib/messages/RAMFMessage';
-export { RecipientAddressType } from './lib/messages/RecipientAddressType';
 export { default as Parcel } from './lib/messages/Parcel';
 export { default as ServiceMessage } from './lib/messages/payloads/ServiceMessage';
 export { default as Cargo } from './lib/messages/Cargo';

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ export { PrivateGateway } from './lib/nodes/PrivateGateway';
 export { CargoMessageStream } from './lib/nodes/CargoMessageStream';
 export { Channel } from './lib/nodes/channels/Channel';
 export { GatewayChannel } from './lib/nodes/channels/GatewayChannel';
-export { PrivatePublicGatewayChannel } from './lib/nodes/channels/PrivatePublicGatewayChannel';
+export { PrivateInternetGatewayChannel } from './lib/nodes/channels/PrivateInternetGatewayChannel';
 
 //endregion
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,4 +105,4 @@ export { PrivatePublicGatewayChannel } from './lib/nodes/channels/PrivatePublicG
 export { NodeCryptoOptions } from './lib/nodes/NodeCryptoOptions';
 export { PublicNodeConnectionParams } from './lib/nodes/PublicNodeConnectionParams';
 export * from './lib/nodes/errors';
-export * from './lib/publicAddressing';
+export * from './lib/internetAddressing';

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ export { default as RAMFError } from './lib/ramf/RAMFError';
 export { default as RAMFSyntaxError } from './lib/ramf/RAMFSyntaxError';
 export { MAX_RAMF_MESSAGE_LENGTH } from './lib/ramf/serialization';
 export { default as RAMFMessage } from './lib/messages/RAMFMessage';
+export { Recipient } from './lib/messages/Recipient';
 export { default as Parcel } from './lib/messages/Parcel';
 export { default as ServiceMessage } from './lib/messages/payloads/ServiceMessage';
 export { default as Cargo } from './lib/messages/Cargo';

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export {
   getPublicKeyDigest,
   getPublicKeyDigestHex,
   getRSAPublicKeyFromPrivate,
-  getPrivateAddressFromIdentityKey,
+  getIdFromIdentityKey,
   RSAKeyGenOptions,
 } from './lib/crypto_wrappers/keys';
 export { PrivateKey, RsaPssPrivateKey } from './lib/crypto_wrappers/PrivateKey';

--- a/src/integration_tests/internetAddressing.test.ts
+++ b/src/integration_tests/internetAddressing.test.ts
@@ -1,11 +1,11 @@
-import { BindingType, resolvePublicAddress } from '..';
+import { BindingType, resolveInternetAddress } from '..';
 
-describe('resolvePublicAddress', () => {
-  const EXISTING_PUBLIC_ADDRESS = 'frankfurt.relaycorp.cloud';
-  const NON_EXISTING_ADDRESS = 'unlikely-to-ever-exist.relaycorp.cloud';
+describe('resolveInternetAddress', () => {
+  const EXISTING_INTERNET_ADDRESS = 'frankfurt.relaycorp.cloud';
+  const NON_EXISTING_ADDRESS = 'unlikely-to-ever-exist-f5e6yht34.relaycorp.cloud';
 
   test('Existing address should be resolved', async () => {
-    const address = await resolvePublicAddress(EXISTING_PUBLIC_ADDRESS, BindingType.PDC);
+    const address = await resolveInternetAddress(EXISTING_INTERNET_ADDRESS, BindingType.PDC);
 
     expect(address?.host).toBeString();
     expect(address?.port).toBeNumber();
@@ -15,9 +15,9 @@ describe('resolvePublicAddress', () => {
     // This is important to check because CloudFlare and Google DNS resolvers are slightly
     // different. For example, Google's adds a trailing dot to the target host.
 
-    const cfAddress = await resolvePublicAddress(EXISTING_PUBLIC_ADDRESS, BindingType.PDC);
-    const gAddress = await resolvePublicAddress(
-      EXISTING_PUBLIC_ADDRESS,
+    const cfAddress = await resolveInternetAddress(EXISTING_INTERNET_ADDRESS, BindingType.PDC);
+    const gAddress = await resolveInternetAddress(
+      EXISTING_INTERNET_ADDRESS,
       BindingType.PDC,
       'https://dns.google/dns-query',
     );
@@ -26,17 +26,17 @@ describe('resolvePublicAddress', () => {
   });
 
   test('Invalid DNSSEC configuration should be refused', async () => {
-    await expect(resolvePublicAddress('dnssec-failed.org', BindingType.PDC)).toReject();
+    await expect(resolveInternetAddress('dnssec-failed.org', BindingType.PDC)).toReject();
   });
 
   test('Non-existing addresses should not be resolved', async () => {
-    await expect(resolvePublicAddress(NON_EXISTING_ADDRESS, BindingType.PDC)).resolves.toBeNull();
+    await expect(resolveInternetAddress(NON_EXISTING_ADDRESS, BindingType.PDC)).resolves.toBeNull();
   });
 
   test('Non-existing address should resolve if port is contained', async () => {
     const port = 1234;
     await expect(
-      resolvePublicAddress(`${NON_EXISTING_ADDRESS}:${port}`, BindingType.PDC),
+      resolveInternetAddress(`${NON_EXISTING_ADDRESS}:${port}`, BindingType.PDC),
     ).resolves.toEqual({ host: NON_EXISTING_ADDRESS, port });
   });
 });

--- a/src/integration_tests/pki.test.ts
+++ b/src/integration_tests/pki.test.ts
@@ -74,7 +74,7 @@ test('Messages by authorized senders should be accepted', async () => {
     },
   );
 
-  await parcel.validate(undefined, [publicGatewayCert]);
+  await parcel.validate([publicGatewayCert]);
 });
 
 test('Certificate chain should be computed corrected', async () => {
@@ -113,7 +113,7 @@ test('Messages by unauthorized senders should be refused', async () => {
     },
   );
 
-  await expect(parcel.validate(undefined, [publicGatewayCert])).rejects.toHaveProperty(
+  await expect(parcel.validate([publicGatewayCert])).rejects.toHaveProperty(
     'message',
     'Sender is not authorized: No valid certificate paths found',
   );

--- a/src/integration_tests/pki.test.ts
+++ b/src/integration_tests/pki.test.ts
@@ -52,7 +52,7 @@ beforeAll(async () => {
     }),
   );
 
-  peerEndpointId = await peerEndpointCert.calculateSubjectPrivateAddress();
+  peerEndpointId = await peerEndpointCert.calculateSubjectId();
 
   const endpointKeyPair = await generateRSAKeyPair();
   endpointPdaCert = reSerializeCertificate(

--- a/src/integration_tests/pki.test.ts
+++ b/src/integration_tests/pki.test.ts
@@ -14,17 +14,17 @@ const ONE_SECOND_AGO = subSeconds(new Date(), 1);
 
 const TOMORROW = addDays(new Date(), 1);
 
-let publicGatewayCert: Certificate;
+let internetGatewayCert: Certificate;
 let privateGatewayCert: Certificate;
 let peerEndpointId: string;
 let peerEndpointCert: Certificate;
 let endpointPdaCert: Certificate;
 beforeAll(async () => {
-  const publicGatewayKeyPair = await generateRSAKeyPair();
-  publicGatewayCert = reSerializeCertificate(
+  const internetGatewayKeyPair = await generateRSAKeyPair();
+  internetGatewayCert = reSerializeCertificate(
     await issueGatewayCertificate({
-      issuerPrivateKey: publicGatewayKeyPair.privateKey,
-      subjectPublicKey: publicGatewayKeyPair.publicKey,
+      issuerPrivateKey: internetGatewayKeyPair.privateKey,
+      subjectPublicKey: internetGatewayKeyPair.publicKey,
       validityEndDate: TOMORROW,
       validityStartDate: ONE_SECOND_AGO,
     }),
@@ -33,8 +33,8 @@ beforeAll(async () => {
   const localGatewayKeyPair = await generateRSAKeyPair();
   privateGatewayCert = reSerializeCertificate(
     await issueGatewayCertificate({
-      issuerCertificate: publicGatewayCert,
-      issuerPrivateKey: publicGatewayKeyPair.privateKey,
+      issuerCertificate: internetGatewayCert,
+      issuerPrivateKey: internetGatewayKeyPair.privateKey,
       subjectPublicKey: localGatewayKeyPair.publicKey,
       validityEndDate: TOMORROW,
       validityStartDate: ONE_SECOND_AGO,
@@ -72,7 +72,7 @@ test('Messages by authorized senders should be accepted', async () => {
     senderCaCertificateChain: [peerEndpointCert, privateGatewayCert],
   });
 
-  await parcel.validate([publicGatewayCert]);
+  await parcel.validate([internetGatewayCert]);
 });
 
 test('Certificate chain should be computed corrected', async () => {
@@ -80,11 +80,11 @@ test('Certificate chain should be computed corrected', async () => {
     senderCaCertificateChain: [peerEndpointCert, privateGatewayCert],
   });
 
-  await expect(parcel.getSenderCertificationPath([publicGatewayCert])).resolves.toEqual([
+  await expect(parcel.getSenderCertificationPath([internetGatewayCert])).resolves.toEqual([
     expect.toSatisfy((c) => c.isEqual(endpointPdaCert)),
     expect.toSatisfy((c) => c.isEqual(peerEndpointCert)),
     expect.toSatisfy((c) => c.isEqual(privateGatewayCert)),
-    expect.toSatisfy((c) => c.isEqual(publicGatewayCert)),
+    expect.toSatisfy((c) => c.isEqual(internetGatewayCert)),
   ]);
 });
 
@@ -108,7 +108,7 @@ test('Messages by unauthorized senders should be refused', async () => {
     },
   );
 
-  await expect(parcel.validate([publicGatewayCert])).rejects.toHaveProperty(
+  await expect(parcel.validate([internetGatewayCert])).rejects.toHaveProperty(
     'message',
     'Sender is not authorized: No valid certificate paths found',
   );

--- a/src/lib/IdentityKeyPair.ts
+++ b/src/lib/IdentityKeyPair.ts
@@ -1,3 +1,3 @@
 export interface IdentityKeyPair extends CryptoKeyPair {
-  readonly privateAddress: string;
+  readonly id: string;
 }

--- a/src/lib/_test_utils.ts
+++ b/src/lib/_test_utils.ts
@@ -1,4 +1,4 @@
-import * as asn1js from 'asn1js';
+import { BaseBlock, Constructed, Primitive } from 'asn1js';
 import bufferToArray from 'buffer-to-arraybuffer';
 import { createHash } from 'crypto';
 import * as pkijs from 'pkijs';
@@ -169,14 +169,28 @@ export async function asyncIterableToArray<T>(iterable: AsyncIterable<T>): Promi
   return values;
 }
 
-export function getAsn1SequenceItem(
-  fields: asn1js.Sequence | asn1js.BaseBlock<any>,
+export function getPrimitiveItemFromConstructed(
+  fields: BaseBlock<any>,
   itemIndex: number,
-): asn1js.Primitive {
-  expect(fields).toBeInstanceOf(asn1js.Sequence);
-  const itemBlock = (fields as asn1js.Sequence).valueBlock.value[itemIndex] as asn1js.Primitive;
-  expect(itemBlock).toBeInstanceOf(asn1js.Primitive);
+): Primitive {
+  const itemBlock = getItemFromConstructed(fields, itemIndex);
+  expect(itemBlock).toBeInstanceOf(Primitive);
+  return itemBlock as Primitive;
+}
+
+export function getConstructedItemFromConstructed(
+  fields: BaseBlock<any>,
+  itemIndex: number,
+): Constructed {
+  const itemBlock = getItemFromConstructed(fields, itemIndex);
+  expect(itemBlock).toBeInstanceOf(Constructed);
+  return itemBlock as Constructed;
+}
+
+function getItemFromConstructed(fields: BaseBlock<any>, itemIndex: number): BaseBlock<any> {
+  expect(fields).toBeInstanceOf(Constructed);
+  const itemBlock = fields.valueBlock.value[itemIndex];
   expect(itemBlock.idBlock.tagClass).toEqual(3); // Context-specific
   expect(itemBlock.idBlock.tagNumber).toEqual(itemIndex);
-  return itemBlock as any;
+  return itemBlock;
 }

--- a/src/lib/bindings/gsc/ParcelCollection.spec.ts
+++ b/src/lib/bindings/gsc/ParcelCollection.spec.ts
@@ -61,7 +61,7 @@ beforeAll(async () => {
 let recipient: Recipient;
 beforeAll(async () => {
   recipient = {
-    id: await recipientCertificate.calculateSubjectPrivateAddress(),
+    id: await recipientCertificate.calculateSubjectId(),
   };
 });
 

--- a/src/lib/bindings/gsc/ParcelCollection.spec.ts
+++ b/src/lib/bindings/gsc/ParcelCollection.spec.ts
@@ -1,3 +1,5 @@
+import { addDays } from 'date-fns';
+
 import {
   arrayBufferFrom,
   expectArrayBuffersToEqual,
@@ -8,6 +10,7 @@ import { generateRSAKeyPair } from '../../crypto_wrappers/keys';
 import Certificate from '../../crypto_wrappers/x509/Certificate';
 import InvalidMessageError from '../../messages/InvalidMessageError';
 import Parcel from '../../messages/Parcel';
+import { Recipient } from '../../messages/Recipient';
 import {
   issueDeliveryAuthorization,
   issueEndpointCertificate,
@@ -23,8 +26,7 @@ let pdaCertificate: Certificate;
 let recipientCertificate: Certificate;
 let gatewayCertificate: Certificate;
 beforeAll(async () => {
-  const tomorrow = new Date();
-  tomorrow.setDate(tomorrow.getDate() + 1);
+  const tomorrow = addDays(new Date(), 1);
 
   const caKeyPair = await generateRSAKeyPair();
   gatewayCertificate = reSerializeCertificate(
@@ -54,6 +56,13 @@ beforeAll(async () => {
       validityEndDate: tomorrow,
     }),
   );
+});
+
+let recipient: Recipient;
+beforeAll(async () => {
+  recipient = {
+    id: await recipientCertificate.calculateSubjectPrivateAddress(),
+  };
 });
 
 test('Parcel serialized should be honored', () => {
@@ -88,27 +97,12 @@ describe('deserializeAndValidateParcel', () => {
     await expect(collection.deserializeAndValidateParcel()).rejects.toBeInstanceOf(RAMFSyntaxError);
   });
 
-  test('Parcels bound for public endpoints should be refused', async () => {
-    const parcel = new Parcel('https://example.com', pdaCertificate, Buffer.from([]), {
-      senderCaCertificateChain: [gatewayCertificate],
-    });
-    const collection = new ParcelCollection(
-      await parcel.serialize(pdaGranteeKeyPair.privateKey),
-      [gatewayCertificate],
-      jest.fn(),
-    );
-
-    await expect(collection.deserializeAndValidateParcel()).rejects.toBeInstanceOf(
-      InvalidMessageError,
-    );
-  });
-
   test('Parcels from unauthorized senders should be refused', async () => {
     const unauthorizedSenderCertificate = await generateStubCert({
       issuerPrivateKey: pdaGranteeKeyPair.privateKey,
       subjectPublicKey: pdaGranteeKeyPair.publicKey,
     });
-    const parcel = new Parcel('0deadbeef', unauthorizedSenderCertificate, Buffer.from([]));
+    const parcel = new Parcel(recipient, unauthorizedSenderCertificate, Buffer.from([]));
     const collection = new ParcelCollection(
       await parcel.serialize(pdaGranteeKeyPair.privateKey),
       [gatewayCertificate],
@@ -121,12 +115,9 @@ describe('deserializeAndValidateParcel', () => {
   });
 
   test('Valid parcels should be returned', async () => {
-    const parcel = new Parcel(
-      await recipientCertificate.calculateSubjectPrivateAddress(),
-      pdaCertificate,
-      Buffer.from([]),
-      { senderCaCertificateChain: [recipientCertificate] },
-    );
+    const parcel = new Parcel(recipient, pdaCertificate, Buffer.from([]), {
+      senderCaCertificateChain: [recipientCertificate],
+    });
     const collection = new ParcelCollection(
       await parcel.serialize(pdaGranteeKeyPair.privateKey),
       [gatewayCertificate],

--- a/src/lib/bindings/gsc/ParcelCollection.ts
+++ b/src/lib/bindings/gsc/ParcelCollection.ts
@@ -1,6 +1,5 @@
 import Certificate from '../../crypto_wrappers/x509/Certificate';
 import Parcel from '../../messages/Parcel';
-import { RecipientAddressType } from '../../messages/RecipientAddressType';
 
 export class ParcelCollection {
   constructor(
@@ -15,7 +14,7 @@ export class ParcelCollection {
 
   public async deserializeAndValidateParcel(): Promise<Parcel> {
     const parcel = await Parcel.deserialize(this.parcelSerialized);
-    await parcel.validate(RecipientAddressType.PRIVATE, this.trustedCertificates);
+    await parcel.validate(this.trustedCertificates);
     return parcel;
   }
 }

--- a/src/lib/bindings/gsc/PrivateNodeRegistration.spec.ts
+++ b/src/lib/bindings/gsc/PrivateNodeRegistration.spec.ts
@@ -1,4 +1,4 @@
-import { Constructed, OctetString, Sequence } from 'asn1js';
+import { Constructed, OctetString, Primitive, Sequence, VisibleString } from 'asn1js';
 import bufferToArray from 'buffer-to-arraybuffer';
 
 import { arrayBufferFrom, generateStubCert } from '../../_test_utils';
@@ -20,9 +20,15 @@ beforeAll(async () => {
   sessionKey = (await SessionKeyPair.generate()).sessionKey;
 });
 
+const PUBLIC_GATEWAY_ADDRESS = 'westeros.relaycorp.cloud';
+
 describe('serialize', () => {
   test('Private node certificate should be serialized', async () => {
-    const registration = new PrivateNodeRegistration(privateNodeCertificate, gatewayCertificate);
+    const registration = new PrivateNodeRegistration(
+      privateNodeCertificate,
+      gatewayCertificate,
+      PUBLIC_GATEWAY_ADDRESS,
+    );
 
     const serialization = await registration.serialize();
 
@@ -35,7 +41,11 @@ describe('serialize', () => {
   });
 
   test('Gateway certificate should be serialized', async () => {
-    const registration = new PrivateNodeRegistration(privateNodeCertificate, gatewayCertificate);
+    const registration = new PrivateNodeRegistration(
+      privateNodeCertificate,
+      gatewayCertificate,
+      PUBLIC_GATEWAY_ADDRESS,
+    );
 
     const serialization = await registration.serialize();
 
@@ -47,27 +57,48 @@ describe('serialize', () => {
     );
   });
 
+  test('Public address of public gateway should be serialized', async () => {
+    const registration = new PrivateNodeRegistration(
+      privateNodeCertificate,
+      gatewayCertificate,
+      PUBLIC_GATEWAY_ADDRESS,
+    );
+
+    const serialization = await registration.serialize();
+
+    const sequence = derDeserialize(serialization);
+    const addressPrimitive = (sequence as Sequence).valueBlock.value[2] as Primitive;
+    expect(Buffer.from(addressPrimitive.valueBlock.valueHexView).toString()).toEqual(
+      PUBLIC_GATEWAY_ADDRESS,
+    );
+  });
+
   describe('Session key', () => {
     test('Session key should be absent from serialization if it does not exist', async () => {
-      const registration = new PrivateNodeRegistration(privateNodeCertificate, gatewayCertificate);
+      const registration = new PrivateNodeRegistration(
+        privateNodeCertificate,
+        gatewayCertificate,
+        PUBLIC_GATEWAY_ADDRESS,
+      );
 
       const serialization = await registration.serialize();
 
       const sequence = derDeserialize(serialization);
-      expect((sequence as Sequence).valueBlock.value).toHaveLength(2);
+      expect((sequence as Sequence).valueBlock.value).toHaveLength(3);
     });
 
     test('Session key should be a CONSTRUCTED value', async () => {
       const registration = new PrivateNodeRegistration(
         privateNodeCertificate,
         gatewayCertificate,
+        PUBLIC_GATEWAY_ADDRESS,
         sessionKey,
       );
 
       const serialization = await registration.serialize();
 
       const sequence = derDeserialize(serialization);
-      const sessionKeySequence = (sequence as Sequence).valueBlock.value[2];
+      const sessionKeySequence = (sequence as Sequence).valueBlock.value[3];
       expect(sessionKeySequence).toBeInstanceOf(Constructed);
     });
 
@@ -75,6 +106,7 @@ describe('serialize', () => {
       const registration = new PrivateNodeRegistration(
         privateNodeCertificate,
         gatewayCertificate,
+        PUBLIC_GATEWAY_ADDRESS,
         sessionKey,
       );
 
@@ -82,7 +114,7 @@ describe('serialize', () => {
 
       const sequence = derDeserialize(serialization);
       expect(
-        ((sequence as Sequence).valueBlock.value[2] as Sequence).valueBlock.value[0],
+        ((sequence as Sequence).valueBlock.value[3] as Sequence).valueBlock.value[0],
       ).toHaveProperty('valueBlock.valueHex', bufferToArray(sessionKey.keyId));
     });
 
@@ -90,6 +122,7 @@ describe('serialize', () => {
       const registration = new PrivateNodeRegistration(
         privateNodeCertificate,
         gatewayCertificate,
+        PUBLIC_GATEWAY_ADDRESS,
         sessionKey,
       );
 
@@ -97,7 +130,7 @@ describe('serialize', () => {
 
       const sequence = await derDeserialize(serialization);
       expect(
-        ((sequence as Sequence).valueBlock.value[2] as Sequence).valueBlock.value[1],
+        ((sequence as Sequence).valueBlock.value[3] as Sequence).valueBlock.value[1],
       ).toHaveProperty(
         'valueBlock.valueHex',
         bufferToArray(await derSerializePublicKey(sessionKey.publicKey)),
@@ -118,9 +151,10 @@ describe('deserialize', () => {
     );
   });
 
-  test('Sequence should have at least two items', async () => {
+  test('Sequence should have at least 3 items', async () => {
     const invalidSerialization = makeImplicitlyTaggedSequence(
       new OctetString({ valueHex: arrayBufferFrom('nope.jpg') }),
+      new OctetString({ valueHex: arrayBufferFrom('nope.png') }),
     ).toBER();
 
     await expect(() =>
@@ -135,6 +169,7 @@ describe('deserialize', () => {
     const invalidSerialization = makeImplicitlyTaggedSequence(
       new OctetString({ valueHex: arrayBufferFrom('not a certificate') }),
       new OctetString({ valueHex: gatewayCertificate.serialize() }),
+      new VisibleString({ value: PUBLIC_GATEWAY_ADDRESS }),
     ).toBER();
 
     await expect(() =>
@@ -146,6 +181,7 @@ describe('deserialize', () => {
     const invalidSerialization = makeImplicitlyTaggedSequence(
       new OctetString({ valueHex: gatewayCertificate.serialize() }),
       new OctetString({ valueHex: arrayBufferFrom('not a certificate') }),
+      new VisibleString({ value: PUBLIC_GATEWAY_ADDRESS }),
     ).toBER();
 
     await expect(() =>
@@ -153,11 +189,28 @@ describe('deserialize', () => {
     ).rejects.toThrowWithMessage(InvalidMessageError, /^Gateway certificate is invalid:/);
   });
 
+  test('Malformed public address of public gateway should be refused', async () => {
+    const invalidAddress = `${PUBLIC_GATEWAY_ADDRESS}-`;
+    const invalidSerialization = makeImplicitlyTaggedSequence(
+      new OctetString({ valueHex: gatewayCertificate.serialize() }),
+      new OctetString({ valueHex: privateNodeCertificate.serialize() }),
+      new VisibleString({ value: invalidAddress }),
+    ).toBER();
+
+    await expect(() =>
+      PrivateNodeRegistration.deserialize(invalidSerialization),
+    ).rejects.toThrowWithMessage(
+      InvalidMessageError,
+      `Malformed public gateway address (${invalidAddress})`,
+    );
+  });
+
   describe('Session key', () => {
     test('SEQUENCE should contain at least two items', async () => {
       const invalidSerialization = makeImplicitlyTaggedSequence(
         new OctetString({ valueHex: gatewayCertificate.serialize() }),
         new OctetString({ valueHex: privateNodeCertificate.serialize() }),
+        new VisibleString({ value: PUBLIC_GATEWAY_ADDRESS }),
         makeImplicitlyTaggedSequence(
           new OctetString({ valueHex: bufferToArray(sessionKey.keyId) }),
         ),
@@ -175,6 +228,7 @@ describe('deserialize', () => {
       const invalidRegistration = new PrivateNodeRegistration(
         privateNodeCertificate,
         gatewayCertificate,
+        PUBLIC_GATEWAY_ADDRESS,
         {
           keyId: sessionKey.keyId,
           publicKey: await gatewayCertificate.getPublicKey(), // Invalid key type (RSA)
@@ -195,6 +249,7 @@ describe('deserialize', () => {
     const registration = new PrivateNodeRegistration(
       privateNodeCertificate,
       gatewayCertificate,
+      PUBLIC_GATEWAY_ADDRESS,
       sessionKey,
     );
 
@@ -205,6 +260,7 @@ describe('deserialize', () => {
       registrationDeserialized.privateNodeCertificate.isEqual(privateNodeCertificate),
     ).toBeTrue();
     expect(registrationDeserialized.gatewayCertificate.isEqual(gatewayCertificate)).toBeTrue();
+    expect(registrationDeserialized.publicGatewayPublicAddress).toEqual(PUBLIC_GATEWAY_ADDRESS);
     expect(registrationDeserialized.sessionKey!!.keyId).toEqual(sessionKey.keyId);
     await expect(
       derSerializePublicKey(registrationDeserialized.sessionKey!!.publicKey),
@@ -212,7 +268,11 @@ describe('deserialize', () => {
   });
 
   test('Valid registration without session key should be accepted', async () => {
-    const registration = new PrivateNodeRegistration(privateNodeCertificate, gatewayCertificate);
+    const registration = new PrivateNodeRegistration(
+      privateNodeCertificate,
+      gatewayCertificate,
+      PUBLIC_GATEWAY_ADDRESS,
+    );
 
     const serialization = await registration.serialize();
 
@@ -221,5 +281,6 @@ describe('deserialize', () => {
       registrationDeserialized.privateNodeCertificate.isEqual(privateNodeCertificate),
     ).toBeTrue();
     expect(registrationDeserialized.gatewayCertificate.isEqual(gatewayCertificate)).toBeTrue();
+    expect(registrationDeserialized.publicGatewayPublicAddress).toEqual(PUBLIC_GATEWAY_ADDRESS);
   });
 });

--- a/src/lib/bindings/gsc/PrivateNodeRegistration.spec.ts
+++ b/src/lib/bindings/gsc/PrivateNodeRegistration.spec.ts
@@ -20,14 +20,14 @@ beforeAll(async () => {
   sessionKey = (await SessionKeyPair.generate()).sessionKey;
 });
 
-const PUBLIC_GATEWAY_INTERNET_ADDRESS = 'westeros.relaycorp.cloud';
+const INTERNET_GATEWAY_INTERNET_ADDRESS = 'westeros.relaycorp.cloud';
 
 describe('serialize', () => {
   test('Private node certificate should be serialized', async () => {
     const registration = new PrivateNodeRegistration(
       privateNodeCertificate,
       gatewayCertificate,
-      PUBLIC_GATEWAY_INTERNET_ADDRESS,
+      INTERNET_GATEWAY_INTERNET_ADDRESS,
     );
 
     const serialization = await registration.serialize();
@@ -44,7 +44,7 @@ describe('serialize', () => {
     const registration = new PrivateNodeRegistration(
       privateNodeCertificate,
       gatewayCertificate,
-      PUBLIC_GATEWAY_INTERNET_ADDRESS,
+      INTERNET_GATEWAY_INTERNET_ADDRESS,
     );
 
     const serialization = await registration.serialize();
@@ -57,11 +57,11 @@ describe('serialize', () => {
     );
   });
 
-  test('Internet address of public gateway should be serialized', async () => {
+  test('Internet address of Internet gateway should be serialized', async () => {
     const registration = new PrivateNodeRegistration(
       privateNodeCertificate,
       gatewayCertificate,
-      PUBLIC_GATEWAY_INTERNET_ADDRESS,
+      INTERNET_GATEWAY_INTERNET_ADDRESS,
     );
 
     const serialization = await registration.serialize();
@@ -69,7 +69,7 @@ describe('serialize', () => {
     const sequence = derDeserialize(serialization);
     const addressPrimitive = (sequence as Sequence).valueBlock.value[2] as Primitive;
     expect(Buffer.from(addressPrimitive.valueBlock.valueHexView).toString()).toEqual(
-      PUBLIC_GATEWAY_INTERNET_ADDRESS,
+      INTERNET_GATEWAY_INTERNET_ADDRESS,
     );
   });
 
@@ -78,7 +78,7 @@ describe('serialize', () => {
       const registration = new PrivateNodeRegistration(
         privateNodeCertificate,
         gatewayCertificate,
-        PUBLIC_GATEWAY_INTERNET_ADDRESS,
+        INTERNET_GATEWAY_INTERNET_ADDRESS,
       );
 
       const serialization = await registration.serialize();
@@ -91,7 +91,7 @@ describe('serialize', () => {
       const registration = new PrivateNodeRegistration(
         privateNodeCertificate,
         gatewayCertificate,
-        PUBLIC_GATEWAY_INTERNET_ADDRESS,
+        INTERNET_GATEWAY_INTERNET_ADDRESS,
         sessionKey,
       );
 
@@ -106,7 +106,7 @@ describe('serialize', () => {
       const registration = new PrivateNodeRegistration(
         privateNodeCertificate,
         gatewayCertificate,
-        PUBLIC_GATEWAY_INTERNET_ADDRESS,
+        INTERNET_GATEWAY_INTERNET_ADDRESS,
         sessionKey,
       );
 
@@ -122,7 +122,7 @@ describe('serialize', () => {
       const registration = new PrivateNodeRegistration(
         privateNodeCertificate,
         gatewayCertificate,
-        PUBLIC_GATEWAY_INTERNET_ADDRESS,
+        INTERNET_GATEWAY_INTERNET_ADDRESS,
         sessionKey,
       );
 
@@ -169,7 +169,7 @@ describe('deserialize', () => {
     const invalidSerialization = makeImplicitlyTaggedSequence(
       new OctetString({ valueHex: arrayBufferFrom('not a certificate') }),
       new OctetString({ valueHex: gatewayCertificate.serialize() }),
-      new VisibleString({ value: PUBLIC_GATEWAY_INTERNET_ADDRESS }),
+      new VisibleString({ value: INTERNET_GATEWAY_INTERNET_ADDRESS }),
     ).toBER();
 
     await expect(() =>
@@ -181,7 +181,7 @@ describe('deserialize', () => {
     const invalidSerialization = makeImplicitlyTaggedSequence(
       new OctetString({ valueHex: gatewayCertificate.serialize() }),
       new OctetString({ valueHex: arrayBufferFrom('not a certificate') }),
-      new VisibleString({ value: PUBLIC_GATEWAY_INTERNET_ADDRESS }),
+      new VisibleString({ value: INTERNET_GATEWAY_INTERNET_ADDRESS }),
     ).toBER();
 
     await expect(() =>
@@ -189,8 +189,8 @@ describe('deserialize', () => {
     ).rejects.toThrowWithMessage(InvalidMessageError, /^Gateway certificate is invalid:/);
   });
 
-  test('Malformed Internet address of public gateway should be refused', async () => {
-    const invalidAddress = `${PUBLIC_GATEWAY_INTERNET_ADDRESS}-`;
+  test('Malformed Internet address of Internet gateway should be refused', async () => {
+    const invalidAddress = `${INTERNET_GATEWAY_INTERNET_ADDRESS}-`;
     const invalidSerialization = makeImplicitlyTaggedSequence(
       new OctetString({ valueHex: gatewayCertificate.serialize() }),
       new OctetString({ valueHex: privateNodeCertificate.serialize() }),
@@ -201,7 +201,7 @@ describe('deserialize', () => {
       PrivateNodeRegistration.deserialize(invalidSerialization),
     ).rejects.toThrowWithMessage(
       InvalidMessageError,
-      `Malformed public gateway address (${invalidAddress})`,
+      `Malformed Internet gateway address (${invalidAddress})`,
     );
   });
 
@@ -210,7 +210,7 @@ describe('deserialize', () => {
       const invalidSerialization = makeImplicitlyTaggedSequence(
         new OctetString({ valueHex: gatewayCertificate.serialize() }),
         new OctetString({ valueHex: privateNodeCertificate.serialize() }),
-        new VisibleString({ value: PUBLIC_GATEWAY_INTERNET_ADDRESS }),
+        new VisibleString({ value: INTERNET_GATEWAY_INTERNET_ADDRESS }),
         makeImplicitlyTaggedSequence(
           new OctetString({ valueHex: bufferToArray(sessionKey.keyId) }),
         ),
@@ -228,7 +228,7 @@ describe('deserialize', () => {
       const invalidRegistration = new PrivateNodeRegistration(
         privateNodeCertificate,
         gatewayCertificate,
-        PUBLIC_GATEWAY_INTERNET_ADDRESS,
+        INTERNET_GATEWAY_INTERNET_ADDRESS,
         {
           keyId: sessionKey.keyId,
           publicKey: await gatewayCertificate.getPublicKey(), // Invalid key type (RSA)
@@ -249,7 +249,7 @@ describe('deserialize', () => {
     const registration = new PrivateNodeRegistration(
       privateNodeCertificate,
       gatewayCertificate,
-      PUBLIC_GATEWAY_INTERNET_ADDRESS,
+      INTERNET_GATEWAY_INTERNET_ADDRESS,
       sessionKey,
     );
 
@@ -260,8 +260,8 @@ describe('deserialize', () => {
       registrationDeserialized.privateNodeCertificate.isEqual(privateNodeCertificate),
     ).toBeTrue();
     expect(registrationDeserialized.gatewayCertificate.isEqual(gatewayCertificate)).toBeTrue();
-    expect(registrationDeserialized.publicGatewayInternetAddress).toEqual(
-      PUBLIC_GATEWAY_INTERNET_ADDRESS,
+    expect(registrationDeserialized.internetGatewayInternetAddress).toEqual(
+      INTERNET_GATEWAY_INTERNET_ADDRESS,
     );
     expect(registrationDeserialized.sessionKey!!.keyId).toEqual(sessionKey.keyId);
     await expect(
@@ -273,7 +273,7 @@ describe('deserialize', () => {
     const registration = new PrivateNodeRegistration(
       privateNodeCertificate,
       gatewayCertificate,
-      PUBLIC_GATEWAY_INTERNET_ADDRESS,
+      INTERNET_GATEWAY_INTERNET_ADDRESS,
     );
 
     const serialization = await registration.serialize();
@@ -283,8 +283,8 @@ describe('deserialize', () => {
       registrationDeserialized.privateNodeCertificate.isEqual(privateNodeCertificate),
     ).toBeTrue();
     expect(registrationDeserialized.gatewayCertificate.isEqual(gatewayCertificate)).toBeTrue();
-    expect(registrationDeserialized.publicGatewayInternetAddress).toEqual(
-      PUBLIC_GATEWAY_INTERNET_ADDRESS,
+    expect(registrationDeserialized.internetGatewayInternetAddress).toEqual(
+      INTERNET_GATEWAY_INTERNET_ADDRESS,
     );
   });
 });

--- a/src/lib/bindings/gsc/PrivateNodeRegistration.spec.ts
+++ b/src/lib/bindings/gsc/PrivateNodeRegistration.spec.ts
@@ -20,14 +20,14 @@ beforeAll(async () => {
   sessionKey = (await SessionKeyPair.generate()).sessionKey;
 });
 
-const PUBLIC_GATEWAY_ADDRESS = 'westeros.relaycorp.cloud';
+const PUBLIC_GATEWAY_INTERNET_ADDRESS = 'westeros.relaycorp.cloud';
 
 describe('serialize', () => {
   test('Private node certificate should be serialized', async () => {
     const registration = new PrivateNodeRegistration(
       privateNodeCertificate,
       gatewayCertificate,
-      PUBLIC_GATEWAY_ADDRESS,
+      PUBLIC_GATEWAY_INTERNET_ADDRESS,
     );
 
     const serialization = await registration.serialize();
@@ -44,7 +44,7 @@ describe('serialize', () => {
     const registration = new PrivateNodeRegistration(
       privateNodeCertificate,
       gatewayCertificate,
-      PUBLIC_GATEWAY_ADDRESS,
+      PUBLIC_GATEWAY_INTERNET_ADDRESS,
     );
 
     const serialization = await registration.serialize();
@@ -57,11 +57,11 @@ describe('serialize', () => {
     );
   });
 
-  test('Public address of public gateway should be serialized', async () => {
+  test('Internet address of public gateway should be serialized', async () => {
     const registration = new PrivateNodeRegistration(
       privateNodeCertificate,
       gatewayCertificate,
-      PUBLIC_GATEWAY_ADDRESS,
+      PUBLIC_GATEWAY_INTERNET_ADDRESS,
     );
 
     const serialization = await registration.serialize();
@@ -69,7 +69,7 @@ describe('serialize', () => {
     const sequence = derDeserialize(serialization);
     const addressPrimitive = (sequence as Sequence).valueBlock.value[2] as Primitive;
     expect(Buffer.from(addressPrimitive.valueBlock.valueHexView).toString()).toEqual(
-      PUBLIC_GATEWAY_ADDRESS,
+      PUBLIC_GATEWAY_INTERNET_ADDRESS,
     );
   });
 
@@ -78,7 +78,7 @@ describe('serialize', () => {
       const registration = new PrivateNodeRegistration(
         privateNodeCertificate,
         gatewayCertificate,
-        PUBLIC_GATEWAY_ADDRESS,
+        PUBLIC_GATEWAY_INTERNET_ADDRESS,
       );
 
       const serialization = await registration.serialize();
@@ -91,7 +91,7 @@ describe('serialize', () => {
       const registration = new PrivateNodeRegistration(
         privateNodeCertificate,
         gatewayCertificate,
-        PUBLIC_GATEWAY_ADDRESS,
+        PUBLIC_GATEWAY_INTERNET_ADDRESS,
         sessionKey,
       );
 
@@ -106,7 +106,7 @@ describe('serialize', () => {
       const registration = new PrivateNodeRegistration(
         privateNodeCertificate,
         gatewayCertificate,
-        PUBLIC_GATEWAY_ADDRESS,
+        PUBLIC_GATEWAY_INTERNET_ADDRESS,
         sessionKey,
       );
 
@@ -122,7 +122,7 @@ describe('serialize', () => {
       const registration = new PrivateNodeRegistration(
         privateNodeCertificate,
         gatewayCertificate,
-        PUBLIC_GATEWAY_ADDRESS,
+        PUBLIC_GATEWAY_INTERNET_ADDRESS,
         sessionKey,
       );
 
@@ -169,7 +169,7 @@ describe('deserialize', () => {
     const invalidSerialization = makeImplicitlyTaggedSequence(
       new OctetString({ valueHex: arrayBufferFrom('not a certificate') }),
       new OctetString({ valueHex: gatewayCertificate.serialize() }),
-      new VisibleString({ value: PUBLIC_GATEWAY_ADDRESS }),
+      new VisibleString({ value: PUBLIC_GATEWAY_INTERNET_ADDRESS }),
     ).toBER();
 
     await expect(() =>
@@ -181,7 +181,7 @@ describe('deserialize', () => {
     const invalidSerialization = makeImplicitlyTaggedSequence(
       new OctetString({ valueHex: gatewayCertificate.serialize() }),
       new OctetString({ valueHex: arrayBufferFrom('not a certificate') }),
-      new VisibleString({ value: PUBLIC_GATEWAY_ADDRESS }),
+      new VisibleString({ value: PUBLIC_GATEWAY_INTERNET_ADDRESS }),
     ).toBER();
 
     await expect(() =>
@@ -189,8 +189,8 @@ describe('deserialize', () => {
     ).rejects.toThrowWithMessage(InvalidMessageError, /^Gateway certificate is invalid:/);
   });
 
-  test('Malformed public address of public gateway should be refused', async () => {
-    const invalidAddress = `${PUBLIC_GATEWAY_ADDRESS}-`;
+  test('Malformed Internet address of public gateway should be refused', async () => {
+    const invalidAddress = `${PUBLIC_GATEWAY_INTERNET_ADDRESS}-`;
     const invalidSerialization = makeImplicitlyTaggedSequence(
       new OctetString({ valueHex: gatewayCertificate.serialize() }),
       new OctetString({ valueHex: privateNodeCertificate.serialize() }),
@@ -210,7 +210,7 @@ describe('deserialize', () => {
       const invalidSerialization = makeImplicitlyTaggedSequence(
         new OctetString({ valueHex: gatewayCertificate.serialize() }),
         new OctetString({ valueHex: privateNodeCertificate.serialize() }),
-        new VisibleString({ value: PUBLIC_GATEWAY_ADDRESS }),
+        new VisibleString({ value: PUBLIC_GATEWAY_INTERNET_ADDRESS }),
         makeImplicitlyTaggedSequence(
           new OctetString({ valueHex: bufferToArray(sessionKey.keyId) }),
         ),
@@ -228,7 +228,7 @@ describe('deserialize', () => {
       const invalidRegistration = new PrivateNodeRegistration(
         privateNodeCertificate,
         gatewayCertificate,
-        PUBLIC_GATEWAY_ADDRESS,
+        PUBLIC_GATEWAY_INTERNET_ADDRESS,
         {
           keyId: sessionKey.keyId,
           publicKey: await gatewayCertificate.getPublicKey(), // Invalid key type (RSA)
@@ -249,7 +249,7 @@ describe('deserialize', () => {
     const registration = new PrivateNodeRegistration(
       privateNodeCertificate,
       gatewayCertificate,
-      PUBLIC_GATEWAY_ADDRESS,
+      PUBLIC_GATEWAY_INTERNET_ADDRESS,
       sessionKey,
     );
 
@@ -260,7 +260,9 @@ describe('deserialize', () => {
       registrationDeserialized.privateNodeCertificate.isEqual(privateNodeCertificate),
     ).toBeTrue();
     expect(registrationDeserialized.gatewayCertificate.isEqual(gatewayCertificate)).toBeTrue();
-    expect(registrationDeserialized.publicGatewayPublicAddress).toEqual(PUBLIC_GATEWAY_ADDRESS);
+    expect(registrationDeserialized.publicGatewayInternetAddress).toEqual(
+      PUBLIC_GATEWAY_INTERNET_ADDRESS,
+    );
     expect(registrationDeserialized.sessionKey!!.keyId).toEqual(sessionKey.keyId);
     await expect(
       derSerializePublicKey(registrationDeserialized.sessionKey!!.publicKey),
@@ -271,7 +273,7 @@ describe('deserialize', () => {
     const registration = new PrivateNodeRegistration(
       privateNodeCertificate,
       gatewayCertificate,
-      PUBLIC_GATEWAY_ADDRESS,
+      PUBLIC_GATEWAY_INTERNET_ADDRESS,
     );
 
     const serialization = await registration.serialize();
@@ -281,6 +283,8 @@ describe('deserialize', () => {
       registrationDeserialized.privateNodeCertificate.isEqual(privateNodeCertificate),
     ).toBeTrue();
     expect(registrationDeserialized.gatewayCertificate.isEqual(gatewayCertificate)).toBeTrue();
-    expect(registrationDeserialized.publicGatewayPublicAddress).toEqual(PUBLIC_GATEWAY_ADDRESS);
+    expect(registrationDeserialized.publicGatewayInternetAddress).toEqual(
+      PUBLIC_GATEWAY_INTERNET_ADDRESS,
+    );
   });
 });

--- a/src/lib/bindings/gsc/PrivateNodeRegistration.ts
+++ b/src/lib/bindings/gsc/PrivateNodeRegistration.ts
@@ -1,5 +1,7 @@
-import { Constructed, OctetString, Primitive, verifySchema } from 'asn1js';
+import { Constructed, OctetString, Primitive, verifySchema, VisibleString } from 'asn1js';
 import bufferToArray from 'buffer-to-arraybuffer';
+import isValidDomain from 'is-valid-domain';
+import { TextDecoder } from 'util';
 
 import { makeHeterogeneousSequenceSchema, makeImplicitlyTaggedSequence } from '../../asn1';
 import { derDeserializeECDHPublicKey, derSerializePublicKey } from '../../crypto_wrappers/keys';
@@ -33,27 +35,44 @@ export class PrivateNodeRegistration {
       throw new InvalidMessageError(err as Error, 'Gateway certificate is invalid');
     }
 
+    const textDecoder = new TextDecoder();
+    const publicGatewayPublicAddress = textDecoder.decode(
+      registrationASN1.publicGatewayPublicAddress.valueBlock.valueHex,
+    );
+    if (!isValidDomain(publicGatewayPublicAddress)) {
+      throw new InvalidMessageError(
+        `Malformed public gateway address (${publicGatewayPublicAddress})`,
+      );
+    }
+
     const sessionKey = await deserializeSessionKey(registrationASN1.sessionKey);
 
-    return new PrivateNodeRegistration(privateNodeCertificate, gatewayCertificate, sessionKey);
+    return new PrivateNodeRegistration(
+      privateNodeCertificate,
+      gatewayCertificate,
+      publicGatewayPublicAddress,
+      sessionKey,
+    );
   }
 
   private static readonly SCHEMA = makeHeterogeneousSequenceSchema('PrivateNodeRegistration', [
     new Primitive({ name: 'privateNodeCertificate' }),
     new Primitive({ name: 'gatewayCertificate' }),
+    new Primitive({ name: 'publicGatewayPublicAddress' }),
     new Constructed({
       name: 'sessionKey',
       optional: true,
       value: [
-        new Primitive({ idBlock: { tagClass: 3, tagNumber: 0 } } as any),
-        new Primitive({ idBlock: { tagClass: 3, tagNumber: 1 } } as any),
+        new Primitive({ idBlock: { tagClass: 3, tagNumber: 0 } }),
+        new Primitive({ idBlock: { tagClass: 3, tagNumber: 1 } }),
       ],
-    } as any),
+    }),
   ]);
 
   constructor(
     public readonly privateNodeCertificate: Certificate,
     public readonly gatewayCertificate: Certificate,
+    public readonly publicGatewayPublicAddress: string,
     public readonly sessionKey: SessionKey | null = null,
   ) {}
 
@@ -70,6 +89,7 @@ export class PrivateNodeRegistration {
     return makeImplicitlyTaggedSequence(
       new OctetString({ valueHex: this.privateNodeCertificate.serialize() }),
       new OctetString({ valueHex: this.gatewayCertificate.serialize() }),
+      new VisibleString({ value: this.publicGatewayPublicAddress }),
       ...(sessionKeySequence ? [sessionKeySequence] : []),
     ).toBER();
   }
@@ -86,7 +106,9 @@ async function deserializeSessionKey(sessionKeySequence: any): Promise<SessionKe
   const sessionKeyIdASN1 = sessionKeySequence.valueBlock.value[0] as Primitive;
   let sessionPublicKey: CryptoKey;
   try {
-    sessionPublicKey = await derDeserializeECDHPublicKey(sessionPublicKeyASN1.valueBlock.valueHex);
+    sessionPublicKey = await derDeserializeECDHPublicKey(
+      sessionPublicKeyASN1.valueBlock.valueHexView,
+    );
   } catch (err: any) {
     throw new InvalidMessageError(
       new Error(err), // The original error could be a string 🤦
@@ -94,7 +116,7 @@ async function deserializeSessionKey(sessionKeySequence: any): Promise<SessionKe
     );
   }
   return {
-    keyId: Buffer.from(sessionKeyIdASN1.valueBlock.valueHex),
+    keyId: Buffer.from(sessionKeyIdASN1.valueBlock.valueHexView),
     publicKey: sessionPublicKey,
   };
 }

--- a/src/lib/bindings/gsc/PrivateNodeRegistration.ts
+++ b/src/lib/bindings/gsc/PrivateNodeRegistration.ts
@@ -36,12 +36,12 @@ export class PrivateNodeRegistration {
     }
 
     const textDecoder = new TextDecoder();
-    const publicGatewayInternetAddress = textDecoder.decode(
-      registrationASN1.publicGatewayInternetAddress.valueBlock.valueHex,
+    const internetGatewayInternetAddress = textDecoder.decode(
+      registrationASN1.internetGatewayInternetAddress.valueBlock.valueHex,
     );
-    if (!isValidDomain(publicGatewayInternetAddress)) {
+    if (!isValidDomain(internetGatewayInternetAddress)) {
       throw new InvalidMessageError(
-        `Malformed public gateway address (${publicGatewayInternetAddress})`,
+        `Malformed Internet gateway address (${internetGatewayInternetAddress})`,
       );
     }
 
@@ -50,7 +50,7 @@ export class PrivateNodeRegistration {
     return new PrivateNodeRegistration(
       privateNodeCertificate,
       gatewayCertificate,
-      publicGatewayInternetAddress,
+      internetGatewayInternetAddress,
       sessionKey,
     );
   }
@@ -58,7 +58,7 @@ export class PrivateNodeRegistration {
   private static readonly SCHEMA = makeHeterogeneousSequenceSchema('PrivateNodeRegistration', [
     new Primitive({ name: 'privateNodeCertificate' }),
     new Primitive({ name: 'gatewayCertificate' }),
-    new Primitive({ name: 'publicGatewayInternetAddress' }),
+    new Primitive({ name: 'internetGatewayInternetAddress' }),
     new Constructed({
       name: 'sessionKey',
       optional: true,
@@ -72,7 +72,7 @@ export class PrivateNodeRegistration {
   constructor(
     public readonly privateNodeCertificate: Certificate,
     public readonly gatewayCertificate: Certificate,
-    public readonly publicGatewayInternetAddress: string,
+    public readonly internetGatewayInternetAddress: string,
     public readonly sessionKey: SessionKey | null = null,
   ) {}
 
@@ -89,7 +89,7 @@ export class PrivateNodeRegistration {
     return makeImplicitlyTaggedSequence(
       new OctetString({ valueHex: this.privateNodeCertificate.serialize() }),
       new OctetString({ valueHex: this.gatewayCertificate.serialize() }),
-      new VisibleString({ value: this.publicGatewayInternetAddress }),
+      new VisibleString({ value: this.internetGatewayInternetAddress }),
       ...(sessionKeySequence ? [sessionKeySequence] : []),
     ).toBER();
   }

--- a/src/lib/bindings/gsc/PrivateNodeRegistration.ts
+++ b/src/lib/bindings/gsc/PrivateNodeRegistration.ts
@@ -36,12 +36,12 @@ export class PrivateNodeRegistration {
     }
 
     const textDecoder = new TextDecoder();
-    const publicGatewayPublicAddress = textDecoder.decode(
-      registrationASN1.publicGatewayPublicAddress.valueBlock.valueHex,
+    const publicGatewayInternetAddress = textDecoder.decode(
+      registrationASN1.publicGatewayInternetAddress.valueBlock.valueHex,
     );
-    if (!isValidDomain(publicGatewayPublicAddress)) {
+    if (!isValidDomain(publicGatewayInternetAddress)) {
       throw new InvalidMessageError(
-        `Malformed public gateway address (${publicGatewayPublicAddress})`,
+        `Malformed public gateway address (${publicGatewayInternetAddress})`,
       );
     }
 
@@ -50,7 +50,7 @@ export class PrivateNodeRegistration {
     return new PrivateNodeRegistration(
       privateNodeCertificate,
       gatewayCertificate,
-      publicGatewayPublicAddress,
+      publicGatewayInternetAddress,
       sessionKey,
     );
   }
@@ -58,7 +58,7 @@ export class PrivateNodeRegistration {
   private static readonly SCHEMA = makeHeterogeneousSequenceSchema('PrivateNodeRegistration', [
     new Primitive({ name: 'privateNodeCertificate' }),
     new Primitive({ name: 'gatewayCertificate' }),
-    new Primitive({ name: 'publicGatewayPublicAddress' }),
+    new Primitive({ name: 'publicGatewayInternetAddress' }),
     new Constructed({
       name: 'sessionKey',
       optional: true,
@@ -72,7 +72,7 @@ export class PrivateNodeRegistration {
   constructor(
     public readonly privateNodeCertificate: Certificate,
     public readonly gatewayCertificate: Certificate,
-    public readonly publicGatewayPublicAddress: string,
+    public readonly publicGatewayInternetAddress: string,
     public readonly sessionKey: SessionKey | null = null,
   ) {}
 
@@ -89,7 +89,7 @@ export class PrivateNodeRegistration {
     return makeImplicitlyTaggedSequence(
       new OctetString({ valueHex: this.privateNodeCertificate.serialize() }),
       new OctetString({ valueHex: this.gatewayCertificate.serialize() }),
-      new VisibleString({ value: this.publicGatewayPublicAddress }),
+      new VisibleString({ value: this.publicGatewayInternetAddress }),
       ...(sessionKeySequence ? [sessionKeySequence] : []),
     ).toBER();
   }

--- a/src/lib/bindings/gsc/PrivateNodeRegistrationAuthorization.spec.ts
+++ b/src/lib/bindings/gsc/PrivateNodeRegistrationAuthorization.spec.ts
@@ -14,7 +14,6 @@ describe('PrivateNodeRegistrationAuthorization', () => {
   const expiryDate = moment().millisecond(0).add(1, 'days').toDate();
   const gatewayData = arrayBufferFrom('This is the gateway data');
 
-  // tslint:disable-next-line:no-let
   let gatewayKeyPair: CryptoKeyPair;
   beforeAll(async () => {
     gatewayKeyPair = await generateRSAKeyPair();

--- a/src/lib/bindings/gsc/PrivateNodeRegistrationRequest.spec.ts
+++ b/src/lib/bindings/gsc/PrivateNodeRegistrationRequest.spec.ts
@@ -4,7 +4,7 @@ import {
   generateRSAKeyPair,
   PrivateNodeRegistrationRequest,
 } from '../../../index';
-import { arrayBufferFrom, getAsn1SequenceItem } from '../../_test_utils';
+import { arrayBufferFrom, getPrimitiveItemFromConstructed } from '../../_test_utils';
 import { makeImplicitlyTaggedSequence } from '../../asn1';
 import { derDeserialize } from '../../crypto_wrappers/_utils';
 import { verify } from '../../crypto_wrappers/rsaSigning';
@@ -27,7 +27,7 @@ describe('serialize', () => {
     const serialization = await request.serialize(privateNodeKeyPair.privateKey);
 
     const sequence = derDeserialize(serialization);
-    expect(getAsn1SequenceItem(sequence, 0)).toHaveProperty(
+    expect(getPrimitiveItemFromConstructed(sequence, 0)).toHaveProperty(
       'valueBlock.valueHex',
       arrayBufferFrom(await derSerializePublicKey(privateNodeKeyPair.publicKey)),
     );
@@ -42,7 +42,7 @@ describe('serialize', () => {
     const serialization = await request.serialize(privateNodeKeyPair.privateKey);
 
     const sequence = derDeserialize(serialization);
-    expect(getAsn1SequenceItem(sequence, 1)).toHaveProperty(
+    expect(getPrimitiveItemFromConstructed(sequence, 1)).toHaveProperty(
       'valueBlock.valueHex',
       authorizationSerialized,
     );
@@ -57,7 +57,7 @@ describe('serialize', () => {
     const serialization = await request.serialize(privateNodeKeyPair.privateKey);
 
     const sequence = derDeserialize(serialization);
-    const signature = getAsn1SequenceItem(sequence, 2).valueBlock.valueHex;
+    const signature = getPrimitiveItemFromConstructed(sequence, 2).valueBlock.valueHex;
     const expectedPNRACountersignature = makeImplicitlyTaggedSequence(
       new ObjectIdentifier({
         value: RELAYNET_OIDS.NODE_REGISTRATION.AUTHORIZATION_COUNTERSIGNATURE,

--- a/src/lib/crypto_wrappers/cms/signedData.ts
+++ b/src/lib/crypto_wrappers/cms/signedData.ts
@@ -109,7 +109,6 @@ export class SignedData {
 
   public static deserialize(signedDataSerialized: ArrayBuffer): SignedData {
     const contentInfo = deserializeContentInfo(signedDataSerialized);
-    // tslint:disable-next-line:no-let
     let pkijsSignedData: pkijs.SignedData;
     try {
       pkijsSignedData = new pkijs.SignedData({ schema: contentInfo.content });

--- a/src/lib/crypto_wrappers/keys.spec.ts
+++ b/src/lib/crypto_wrappers/keys.spec.ts
@@ -13,7 +13,7 @@ import {
   derSerializePublicKey,
   generateECDHKeyPair,
   generateRSAKeyPair,
-  getPrivateAddressFromIdentityKey,
+  getIdFromIdentityKey,
   getPublicKeyDigest,
   getPublicKeyDigestHex,
   getRSAPublicKeyFromPrivate,
@@ -430,7 +430,7 @@ describe('getPrivateAddressFromIdentityKey', () => {
   test('Private address should be computed from identity key', async () => {
     const keyPair = await generateRSAKeyPair();
 
-    const privateAddress = await getPrivateAddressFromIdentityKey(keyPair.publicKey);
+    const privateAddress = await getIdFromIdentityKey(keyPair.publicKey);
 
     expect(privateAddress).toEqual('0' + sha256Hex(await derSerializePublicKey(keyPair.publicKey)));
   });
@@ -438,7 +438,7 @@ describe('getPrivateAddressFromIdentityKey', () => {
   test('DH keys should be refused', async () => {
     const keyPair = await generateECDHKeyPair();
 
-    await expect(getPrivateAddressFromIdentityKey(keyPair.publicKey)).rejects.toThrowWithMessage(
+    await expect(getIdFromIdentityKey(keyPair.publicKey)).rejects.toThrowWithMessage(
       Error,
       'Only RSA keys are supported (got ECDH)',
     );

--- a/src/lib/crypto_wrappers/keys.spec.ts
+++ b/src/lib/crypto_wrappers/keys.spec.ts
@@ -426,13 +426,13 @@ test('getPublicKeyDigestHex should return the SHA-256 hex digest of the public k
   expect(digestHex).toEqual(sha256Hex(await derSerializePublicKey(keyPair.publicKey)));
 });
 
-describe('getPrivateAddressFromIdentityKey', () => {
+describe('getIdFromIdentityKey', () => {
   test('Private address should be computed from identity key', async () => {
     const keyPair = await generateRSAKeyPair();
 
-    const privateAddress = await getIdFromIdentityKey(keyPair.publicKey);
+    const id = await getIdFromIdentityKey(keyPair.publicKey);
 
-    expect(privateAddress).toEqual('0' + sha256Hex(await derSerializePublicKey(keyPair.publicKey)));
+    expect(id).toEqual('0' + sha256Hex(await derSerializePublicKey(keyPair.publicKey)));
   });
 
   test('DH keys should be refused', async () => {

--- a/src/lib/crypto_wrappers/keys.spec.ts
+++ b/src/lib/crypto_wrappers/keys.spec.ts
@@ -427,7 +427,7 @@ test('getPublicKeyDigestHex should return the SHA-256 hex digest of the public k
 });
 
 describe('getIdFromIdentityKey', () => {
-  test('Private address should be computed from identity key', async () => {
+  test('Id should be computed from identity key', async () => {
     const keyPair = await generateRSAKeyPair();
 
     const id = await getIdFromIdentityKey(keyPair.publicKey);

--- a/src/lib/crypto_wrappers/keys.ts
+++ b/src/lib/crypto_wrappers/keys.ts
@@ -183,9 +183,7 @@ export async function getPublicKeyDigestHex(publicKey: CryptoKey): Promise<strin
   return digest.toString('hex');
 }
 
-export async function getPrivateAddressFromIdentityKey(
-  identityPublicKey: CryptoKey,
-): Promise<string> {
+export async function getIdFromIdentityKey(identityPublicKey: CryptoKey): Promise<string> {
   const algorithmName = identityPublicKey.algorithm.name;
   if (!algorithmName.startsWith('RSA-')) {
     throw new Error(`Only RSA keys are supported (got ${algorithmName})`);

--- a/src/lib/crypto_wrappers/rsaSigning.spec.ts
+++ b/src/lib/crypto_wrappers/rsaSigning.spec.ts
@@ -9,7 +9,6 @@ const plaintext = arrayBufferFrom('the plaintext');
 
 const pkijsCrypto = utils.getPkijsCrypto();
 
-// tslint:disable-next-line:no-let
 let keyPair: CryptoKeyPair;
 beforeAll(async () => {
   keyPair = await generateRSAKeyPair();

--- a/src/lib/crypto_wrappers/x509/Certificate.spec.ts
+++ b/src/lib/crypto_wrappers/x509/Certificate.spec.ts
@@ -698,7 +698,7 @@ describe('getIssuerId', () => {
     expect(certificate.getIssuerId()).toBeNull();
   });
 
-  test('Private address of issuer should be output if extension is present', async () => {
+  test('Issuer id should be output if extension is present', async () => {
     const certificate = await generateStubCert({
       issuerCertificate,
       issuerPrivateKey: issuerKeyPair.privateKey,

--- a/src/lib/crypto_wrappers/x509/Certificate.spec.ts
+++ b/src/lib/crypto_wrappers/x509/Certificate.spec.ts
@@ -651,7 +651,7 @@ describe('getCommonName()', () => {
   });
 });
 
-describe('calculateSubjectPrivateAddress', () => {
+describe('calculateSubjectId', () => {
   test('Private node address should be returned', async () => {
     const nodeKeyPair = await generateRSAKeyPair();
     const nodeCertificate = await generateStubCert({
@@ -659,7 +659,7 @@ describe('calculateSubjectPrivateAddress', () => {
       subjectPublicKey: nodeKeyPair.publicKey,
     });
 
-    await expect(nodeCertificate.calculateSubjectPrivateAddress()).resolves.toEqual(
+    await expect(nodeCertificate.calculateSubjectId()).resolves.toEqual(
       await getIdFromIdentityKey(nodeKeyPair.publicKey),
     );
   });
@@ -672,20 +672,20 @@ describe('calculateSubjectPrivateAddress', () => {
     });
     const getPublicKeySpy = jest.spyOn(nodeCertificate, 'getPublicKey');
 
-    const address = await nodeCertificate.calculateSubjectPrivateAddress();
-    await expect(nodeCertificate.calculateSubjectPrivateAddress()).resolves.toEqual(address);
+    const address = await nodeCertificate.calculateSubjectId();
+    await expect(nodeCertificate.calculateSubjectId()).resolves.toEqual(address);
 
     expect(getPublicKeySpy).toBeCalledTimes(1);
   });
 });
 
-describe('getIssuerPrivateAddress', () => {
+describe('getIssuerId', () => {
   test('Nothing should be output if there are no extensions', async () => {
     const certificate = await generateStubCert({});
     // tslint:disable-next-line:no-delete no-object-mutation
     delete certificate.pkijsCertificate.extensions;
 
-    expect(certificate.getIssuerPrivateAddress()).toBeNull();
+    expect(certificate.getIssuerId()).toBeNull();
   });
 
   test('Nothing should be output if extension is missing', async () => {
@@ -695,7 +695,7 @@ describe('getIssuerPrivateAddress', () => {
       (e) => e.extnID !== oids.AUTHORITY_KEY,
     );
 
-    expect(certificate.getIssuerPrivateAddress()).toBeNull();
+    expect(certificate.getIssuerId()).toBeNull();
   });
 
   test('Private address of issuer should be output if extension is present', async () => {
@@ -704,9 +704,7 @@ describe('getIssuerPrivateAddress', () => {
       issuerPrivateKey: issuerKeyPair.privateKey,
     });
 
-    expect(certificate.getIssuerPrivateAddress()).toEqual(
-      await issuerCertificate.calculateSubjectPrivateAddress(),
-    );
+    expect(certificate.getIssuerId()).toEqual(await issuerCertificate.calculateSubjectId());
   });
 });
 

--- a/src/lib/crypto_wrappers/x509/Certificate.spec.ts
+++ b/src/lib/crypto_wrappers/x509/Certificate.spec.ts
@@ -7,11 +7,7 @@ import * as pkijs from 'pkijs';
 import { generateStubCert, reSerializeCertificate, sha256Hex } from '../../_test_utils';
 import * as oids from '../../oids';
 import { derDeserialize, getPkijsCrypto } from '../_utils';
-import {
-  derSerializePublicKey,
-  generateRSAKeyPair,
-  getPrivateAddressFromIdentityKey,
-} from '../keys';
+import { derSerializePublicKey, generateRSAKeyPair, getIdFromIdentityKey } from '../keys';
 import { RsaPssPrivateKey } from '../PrivateKey';
 import { MockRsaPssProvider } from '../webcrypto/_test_utils';
 import { getEngineForPrivateKey } from '../webcrypto/engine';
@@ -664,7 +660,7 @@ describe('calculateSubjectPrivateAddress', () => {
     });
 
     await expect(nodeCertificate.calculateSubjectPrivateAddress()).resolves.toEqual(
-      await getPrivateAddressFromIdentityKey(nodeKeyPair.publicKey),
+      await getIdFromIdentityKey(nodeKeyPair.publicKey),
     );
   });
 

--- a/src/lib/crypto_wrappers/x509/Certificate.ts
+++ b/src/lib/crypto_wrappers/x509/Certificate.ts
@@ -4,7 +4,7 @@ import * as pkijs from 'pkijs';
 
 import * as oids from '../../oids';
 import { derDeserialize, generateRandom64BitValue } from '../_utils';
-import { getPrivateAddressFromIdentityKey, getPublicKeyDigest } from '../keys';
+import { getIdFromIdentityKey, getPublicKeyDigest } from '../keys';
 import { getEngineForPrivateKey } from '../webcrypto/engine';
 import CertificateError from './CertificateError';
 import FullCertificateIssuanceOptions from './FullCertificateIssuanceOptions';
@@ -202,7 +202,7 @@ export default class Certificate {
   public async calculateSubjectPrivateAddress(): Promise<string> {
     if (!this.privateAddressCache) {
       // tslint:disable-next-line:no-object-mutation
-      this.privateAddressCache = await getPrivateAddressFromIdentityKey(await this.getPublicKey());
+      this.privateAddressCache = await getIdFromIdentityKey(await this.getPublicKey());
     }
     return this.privateAddressCache;
   }

--- a/src/lib/crypto_wrappers/x509/Certificate.ts
+++ b/src/lib/crypto_wrappers/x509/Certificate.ts
@@ -121,7 +121,7 @@ export default class Certificate {
   public readonly pkijsCertificate: pkijs.Certificate;
 
   // tslint:disable-next-line:readonly-keyword
-  protected privateAddressCache: string | null = null;
+  protected subjectIdCache: string | null = null;
 
   /**
    * @internal
@@ -199,15 +199,15 @@ export default class Certificate {
     }
   }
 
-  public async calculateSubjectPrivateAddress(): Promise<string> {
-    if (!this.privateAddressCache) {
+  public async calculateSubjectId(): Promise<string> {
+    if (!this.subjectIdCache) {
       // tslint:disable-next-line:no-object-mutation
-      this.privateAddressCache = await getIdFromIdentityKey(await this.getPublicKey());
+      this.subjectIdCache = await getIdFromIdentityKey(await this.getPublicKey());
     }
-    return this.privateAddressCache;
+    return this.subjectIdCache;
   }
 
-  public getIssuerPrivateAddress(): string | null {
+  public getIssuerId(): string | null {
     const authorityKeyAttribute = this.pkijsCertificate.extensions?.find(
       (attr) => attr.extnID === oids.AUTHORITY_KEY,
     );

--- a/src/lib/internetAddressing.ts
+++ b/src/lib/internetAddressing.ts
@@ -17,7 +17,7 @@ export enum BindingType {
   PDC = 'awala-pdc',
 }
 
-export class PublicAddressingError extends RelaynetError {}
+export class InternetAddressingError extends RelaynetError {}
 
 export class UnreachableResolverError extends RelaynetError {}
 
@@ -27,8 +27,8 @@ export class UnreachableResolverError extends RelaynetError {}
  * @param hostName The host name to look up
  * @param bindingType The SRV service to look up
  * @param resolverURL The URL for the DNS-over-HTTPS resolver
- * @throws PublicAddressingError If DNSSEC verification failed
- * @throws UnreachableResolverError If the DNS resolver was unreachable
+ * @throws {InternetAddressingError} If DNSSEC verification failed
+ * @throws {UnreachableResolverError} If the DNS resolver was unreachable
  *
  * `null` is returned when `hostName` is an IP address or a non-existing SRV record for the service
  * in `bindingType`.
@@ -38,7 +38,7 @@ export class UnreachableResolverError extends RelaynetError {}
  *
  * DNS resolution is done with DNS-over-HTTPS.
  */
-export async function resolvePublicAddress(
+export async function resolveInternetAddress(
   hostName: string,
   bindingType: BindingType,
   resolverURL = CLOUDFLARE_RESOLVER_URL,
@@ -64,16 +64,16 @@ export async function resolvePublicAddress(
     return null;
   }
   if (result.rcode !== 'NOERROR') {
-    throw new PublicAddressingError(`SRV lookup for ${name} failed with status ${result.rcode}`);
+    throw new InternetAddressingError(`SRV lookup for ${name} failed with status ${result.rcode}`);
   }
   if (!result.flag_ad) {
-    throw new PublicAddressingError(`DNSSEC verification for SRV ${name} failed`);
+    throw new InternetAddressingError(`DNSSEC verification for SRV ${name} failed`);
   }
   const srvAnswers = result.answers.filter((a) => a.type === 'SRV');
   // TODO: Pick the best answer based on its weight and priority fields
   const answer = srvAnswers[0];
   if (!answer || !answer.data || !answer.data.target || !answer.data.port) {
-    throw new PublicAddressingError('DNS answer is malformed');
+    throw new InternetAddressingError('DNS answer is malformed');
   }
   return { host: removeTrailingDot(answer.data.target), port: answer.data.port };
 }

--- a/src/lib/keyStores/CertificateStore.spec.ts
+++ b/src/lib/keyStores/CertificateStore.spec.ts
@@ -1,7 +1,7 @@
 import { addSeconds, setMilliseconds, subSeconds } from 'date-fns';
 import { expectArrayBuffersToEqual } from '../_test_utils';
 
-import { generateRSAKeyPair, getPrivateAddressFromIdentityKey } from '../crypto_wrappers/keys';
+import { generateRSAKeyPair, getIdFromIdentityKey } from '../crypto_wrappers/keys';
 import Certificate from '../crypto_wrappers/x509/Certificate';
 import { CertificationPath } from '../pki/CertificationPath';
 import { issueGatewayCertificate } from '../pki/issuance';
@@ -20,7 +20,7 @@ let subjectCertificate: Certificate;
 let certificationPath: CertificationPath;
 beforeAll(async () => {
   const issuerKeyPair = await generateRSAKeyPair();
-  issuerPrivateAddress = await getPrivateAddressFromIdentityKey(issuerKeyPair.publicKey);
+  issuerPrivateAddress = await getIdFromIdentityKey(issuerKeyPair.publicKey);
   issuerCertificate = await issueGatewayCertificate({
     subjectPublicKey: issuerKeyPair.publicKey,
     issuerPrivateKey: issuerKeyPair.privateKey,
@@ -28,7 +28,7 @@ beforeAll(async () => {
   });
 
   subjectKeyPair = await generateRSAKeyPair();
-  subjectPrivateAddress = await getPrivateAddressFromIdentityKey(subjectKeyPair.publicKey);
+  subjectPrivateAddress = await getIdFromIdentityKey(subjectKeyPair.publicKey);
   subjectCertificate = await issueGatewayCertificate({
     issuerCertificate,
     issuerPrivateKey: issuerKeyPair.privateKey,

--- a/src/lib/keyStores/CertificateStore.spec.ts
+++ b/src/lib/keyStores/CertificateStore.spec.ts
@@ -12,15 +12,15 @@ beforeEach(() => {
   store.clear();
 });
 
-let issuerPrivateAddress: string;
+let issuerId: string;
 let issuerCertificate: Certificate;
 let subjectKeyPair: CryptoKeyPair;
-let subjectPrivateAddress: string;
+let subjectId: string;
 let subjectCertificate: Certificate;
 let certificationPath: CertificationPath;
 beforeAll(async () => {
   const issuerKeyPair = await generateRSAKeyPair();
-  issuerPrivateAddress = await getIdFromIdentityKey(issuerKeyPair.publicKey);
+  issuerId = await getIdFromIdentityKey(issuerKeyPair.publicKey);
   issuerCertificate = await issueGatewayCertificate({
     subjectPublicKey: issuerKeyPair.publicKey,
     issuerPrivateKey: issuerKeyPair.privateKey,
@@ -28,7 +28,7 @@ beforeAll(async () => {
   });
 
   subjectKeyPair = await generateRSAKeyPair();
-  subjectPrivateAddress = await getIdFromIdentityKey(subjectKeyPair.publicKey);
+  subjectId = await getIdFromIdentityKey(subjectKeyPair.publicKey);
   subjectCertificate = await issueGatewayCertificate({
     issuerCertificate,
     issuerPrivateKey: issuerKeyPair.privateKey,
@@ -43,84 +43,64 @@ describe('save', () => {
   test('Expired certificate should not be saved', async () => {
     const certificate = await generateSubjectCertificate(subSeconds(new Date(), 1));
 
-    await store.save(
-      new CertificationPath(certificate, [issuerCertificate]),
-      subjectPrivateAddress,
-    );
+    await store.save(new CertificationPath(certificate, [issuerCertificate]), subjectId);
 
-    expect(store.dataByPrivateAddress).toBeEmpty();
+    expect(store.dataBySubjectId).toBeEmpty();
   });
 
   test('Certification path should be stored', async () => {
-    await store.save(certificationPath, issuerPrivateAddress);
+    await store.save(certificationPath, issuerId);
 
-    expect(store.dataByPrivateAddress).toHaveProperty(subjectPrivateAddress);
-    const serialization = store.dataByPrivateAddress[subjectPrivateAddress][0].serialization;
+    expect(store.dataBySubjectId).toHaveProperty(subjectId);
+    const serialization = store.dataBySubjectId[subjectId][0].serialization;
     expectArrayBuffersToEqual(certificationPath.serialize(), serialization);
   });
 
   test('Expiry date should be taken from certificate', async () => {
-    await store.save(certificationPath, issuerPrivateAddress);
+    await store.save(certificationPath, issuerId);
 
-    expect(store.dataByPrivateAddress).toHaveProperty(subjectPrivateAddress);
-    expect(store.dataByPrivateAddress[subjectPrivateAddress][0].expiryDate).toEqual(
+    expect(store.dataBySubjectId).toHaveProperty(subjectId);
+    expect(store.dataBySubjectId[subjectId][0].expiryDate).toEqual(
       setMilliseconds(subjectCertificate.expiryDate, 0),
     );
   });
 
-  test('Specified issuer private address should be honoured', async () => {
-    const differentIssuerPrivateAddress = `not-${subjectPrivateAddress}`;
+  test('Specified issuer id should be honoured', async () => {
+    const differentIssuerId = `not-${subjectId}`;
 
-    await store.save(certificationPath, differentIssuerPrivateAddress);
+    await store.save(certificationPath, differentIssuerId);
 
-    expect(store.dataByPrivateAddress).toHaveProperty(subjectPrivateAddress);
-    expect(store.dataByPrivateAddress[subjectPrivateAddress][0].issuerPrivateAddress).toEqual(
-      differentIssuerPrivateAddress,
-    );
+    expect(store.dataBySubjectId).toHaveProperty(subjectId);
+    expect(store.dataBySubjectId[subjectId][0].issuerId).toEqual(differentIssuerId);
   });
 });
 
 describe('retrieveLatest', () => {
   test('Nothing should be returned if certificate does not exist', async () => {
-    await expect(
-      store.retrieveLatest(subjectPrivateAddress, issuerPrivateAddress),
-    ).resolves.toBeNull();
+    await expect(store.retrieveLatest(subjectId, issuerId)).resolves.toBeNull();
   });
 
   test('Expired certificate should be ignored', async () => {
     const expiredCertificate = await generateSubjectCertificate(subSeconds(new Date(), 1));
-    await store.forceSave(
-      new CertificationPath(expiredCertificate, [issuerCertificate]),
-      issuerPrivateAddress,
-    );
+    await store.forceSave(new CertificationPath(expiredCertificate, [issuerCertificate]), issuerId);
 
-    await expect(
-      store.retrieveLatest(subjectPrivateAddress, issuerPrivateAddress),
-    ).resolves.toBeNull();
+    await expect(store.retrieveLatest(subjectId, issuerId)).resolves.toBeNull();
   });
 
   test('Certificates from another issuer should be ignored', async () => {
-    await store.save(certificationPath, `not-${issuerPrivateAddress}`);
+    await store.save(certificationPath, `not-${issuerId}`);
 
-    await expect(
-      store.retrieveLatest(subjectPrivateAddress, issuerPrivateAddress),
-    ).resolves.toBeNull();
+    await expect(store.retrieveLatest(subjectId, issuerId)).resolves.toBeNull();
   });
 
   test('Latest path should be returned', async () => {
     const now = new Date();
     const olderCertificate = await generateSubjectCertificate(addSeconds(now, 5));
-    await store.save(
-      new CertificationPath(olderCertificate, [issuerCertificate]),
-      issuerPrivateAddress,
-    );
+    await store.save(new CertificationPath(olderCertificate, [issuerCertificate]), issuerId);
     const newerCertificate = await generateSubjectCertificate(addSeconds(now, 10));
-    await store.save(
-      new CertificationPath(newerCertificate, [issuerCertificate]),
-      issuerPrivateAddress,
-    );
+    await store.save(new CertificationPath(newerCertificate, [issuerCertificate]), issuerId);
 
-    const path = await store.retrieveLatest(subjectPrivateAddress, issuerPrivateAddress);
+    const path = await store.retrieveLatest(subjectId, issuerId);
 
     expect(path!.leafCertificate.isEqual(newerCertificate)).toBeTrue();
     expect(path!.certificateAuthorities).toHaveLength(1);
@@ -130,24 +110,16 @@ describe('retrieveLatest', () => {
 
 describe('retrieveAll', () => {
   test('Nothing should be returned if no certificate exists', async () => {
-    await expect(
-      store.retrieveAll(subjectPrivateAddress, issuerPrivateAddress),
-    ).resolves.toBeEmpty();
+    await expect(store.retrieveAll(subjectId, issuerId)).resolves.toBeEmpty();
   });
 
   test('Expired certificates should be ignored', async () => {
     const validCertificate = await generateSubjectCertificate(addSeconds(new Date(), 3));
-    await store.save(
-      new CertificationPath(validCertificate, [issuerCertificate]),
-      issuerPrivateAddress,
-    );
+    await store.save(new CertificationPath(validCertificate, [issuerCertificate]), issuerId);
     const expiredCertificate = await generateSubjectCertificate(subSeconds(new Date(), 1));
-    await store.forceSave(
-      new CertificationPath(expiredCertificate, [issuerCertificate]),
-      issuerPrivateAddress,
-    );
+    await store.forceSave(new CertificationPath(expiredCertificate, [issuerCertificate]), issuerId);
 
-    const allPaths = await store.retrieveAll(subjectPrivateAddress, issuerPrivateAddress);
+    const allPaths = await store.retrieveAll(subjectId, issuerId);
 
     expect(allPaths).toHaveLength(1);
     expect(validCertificate.isEqual(allPaths[0].leafCertificate)).toBeTrue();
@@ -155,17 +127,11 @@ describe('retrieveAll', () => {
 
   test('All valid certificates should be returned', async () => {
     const certificate1 = await generateSubjectCertificate(addSeconds(new Date(), 3));
-    await store.save(
-      new CertificationPath(certificate1, [issuerCertificate]),
-      issuerPrivateAddress,
-    );
+    await store.save(new CertificationPath(certificate1, [issuerCertificate]), issuerId);
     const certificate2 = await generateSubjectCertificate(addSeconds(new Date(), 5));
-    await store.save(
-      new CertificationPath(certificate2, [issuerCertificate]),
-      issuerPrivateAddress,
-    );
+    await store.save(new CertificationPath(certificate2, [issuerCertificate]), issuerId);
 
-    const allCertificates = await store.retrieveAll(subjectPrivateAddress, issuerPrivateAddress);
+    const allCertificates = await store.retrieveAll(subjectId, issuerId);
 
     expect(allCertificates).toHaveLength(2);
     expect(allCertificates.filter((p) => certificate1.isEqual(p.leafCertificate))).toHaveLength(1);
@@ -178,11 +144,9 @@ describe('retrieveAll', () => {
 
   test('Certificates from another issuer should be ignored', async () => {
     const certificate = await generateSubjectCertificate(addSeconds(new Date(), 3));
-    await store.save(new CertificationPath(certificate, []), `not-${issuerPrivateAddress}`);
+    await store.save(new CertificationPath(certificate, []), `not-${issuerId}`);
 
-    await expect(
-      store.retrieveAll(subjectPrivateAddress, issuerPrivateAddress),
-    ).resolves.toBeEmpty();
+    await expect(store.retrieveAll(subjectId, issuerId)).resolves.toBeEmpty();
   });
 });
 

--- a/src/lib/keyStores/PrivateKeyStore.spec.ts
+++ b/src/lib/keyStores/PrivateKeyStore.spec.ts
@@ -2,7 +2,7 @@ import { HashingAlgorithm, RSAModulus } from '../crypto_wrappers/algorithms';
 import {
   derSerializePrivateKey,
   derSerializePublicKey,
-  getPrivateAddressFromIdentityKey,
+  getIdFromIdentityKey,
 } from '../crypto_wrappers/keys';
 import { SessionKeyPair } from '../SessionKeyPair';
 import { KeyStoreError } from './KeyStoreError';
@@ -50,9 +50,7 @@ describe('Identity keys', () => {
     test('Private address should be returned', async () => {
       const keyPair = await MOCK_STORE.generateIdentityKeyPair();
 
-      expect(keyPair.privateAddress).toEqual(
-        await getPrivateAddressFromIdentityKey(keyPair.publicKey),
-      );
+      expect(keyPair.privateAddress).toEqual(await getIdFromIdentityKey(keyPair.publicKey));
     });
 
     test('Public key should correspond to private key', async () => {

--- a/src/lib/keyStores/PrivateKeyStore.spec.ts
+++ b/src/lib/keyStores/PrivateKeyStore.spec.ts
@@ -47,7 +47,7 @@ describe('Identity keys', () => {
       },
     );
 
-    test('Private address should be returned', async () => {
+    test('Id should be returned', async () => {
       const keyPair = await MOCK_STORE.generateIdentityKeyPair();
 
       expect(keyPair.id).toEqual(await getIdFromIdentityKey(keyPair.publicKey));

--- a/src/lib/keyStores/PrivateKeyStore.ts
+++ b/src/lib/keyStores/PrivateKeyStore.ts
@@ -4,7 +4,7 @@ import {
   derDeserializeECDHPrivateKey,
   derSerializePrivateKey,
   generateRSAKeyPair,
-  getPrivateAddressFromIdentityKey,
+  getIdFromIdentityKey,
   RSAKeyGenOptions,
 } from '../crypto_wrappers/keys';
 import { IdentityKeyPair } from '../IdentityKeyPair';
@@ -27,7 +27,7 @@ export abstract class PrivateKeyStore {
     keyOptions: Partial<RSAKeyGenOptions> = {},
   ): Promise<IdentityKeyPair> {
     const keyPair = await this.generateRSAKeyPair(keyOptions);
-    const privateAddress = await getPrivateAddressFromIdentityKey(keyPair.publicKey);
+    const privateAddress = await getIdFromIdentityKey(keyPair.publicKey);
     try {
       await this.saveIdentityKey(privateAddress, keyPair.privateKey);
     } catch (err) {

--- a/src/lib/keyStores/PrivateKeyStore.ts
+++ b/src/lib/keyStores/PrivateKeyStore.ts
@@ -16,8 +16,8 @@ import UnknownKeyError from './UnknownKeyError';
  */
 export interface SessionPrivateKeyData {
   readonly keySerialized: Buffer;
-  readonly privateAddress: string;
-  readonly peerPrivateAddress?: string;
+  readonly nodeId: string;
+  readonly peerId?: string;
 }
 
 export abstract class PrivateKeyStore {
@@ -27,22 +27,22 @@ export abstract class PrivateKeyStore {
     keyOptions: Partial<RSAKeyGenOptions> = {},
   ): Promise<IdentityKeyPair> {
     const keyPair = await this.generateRSAKeyPair(keyOptions);
-    const privateAddress = await getIdFromIdentityKey(keyPair.publicKey);
+    const id = await getIdFromIdentityKey(keyPair.publicKey);
     try {
-      await this.saveIdentityKey(privateAddress, keyPair.privateKey);
+      await this.saveIdentityKey(id, keyPair.privateKey);
     } catch (err) {
-      throw new KeyStoreError(err as Error, `Failed to save key for ${privateAddress}`);
+      throw new KeyStoreError(err as Error, `Failed to save key for ${id}`);
     }
-    return { ...keyPair, privateAddress };
+    return { ...keyPair, id };
   }
 
   /**
    * Return the private component of a node key pair if it exists.
    *
-   * @param privateAddress
+   * @param nodeId
    * @throws {KeyStoreError} if the backend failed to retrieve the key due to an error
    */
-  public abstract retrieveIdentityKey(privateAddress: string): Promise<CryptoKey | null>;
+  public abstract retrieveIdentityKey(nodeId: string): Promise<CryptoKey | null>;
 
   //endregion
   //region Session keys
@@ -50,18 +50,13 @@ export abstract class PrivateKeyStore {
   public async saveSessionKey(
     privateKey: CryptoKey,
     keyId: Buffer,
-    privateAddress: string,
-    peerPrivateAddress?: string,
+    nodeId: string,
+    peerId?: string,
   ): Promise<void> {
     const keyIdString = keyId.toString('hex');
     const privateKeyDer = await derSerializePrivateKey(privateKey);
     try {
-      await this.saveSessionKeySerialized(
-        keyIdString,
-        privateKeyDer,
-        privateAddress,
-        peerPrivateAddress,
-      );
+      await this.saveSessionKeySerialized(keyIdString, privateKeyDer, nodeId, peerId);
     } catch (error) {
       throw new KeyStoreError(error as Error, `Failed to save key ${keyIdString}`);
     }
@@ -71,17 +66,14 @@ export abstract class PrivateKeyStore {
    * Return the private component of an initial session key pair.
    *
    * @param keyId The key pair id (typically the serial number)
-   * @param privateAddress The private address of the node that owns the key
+   * @param nodeId The private address of the node that owns the key
    * @throws UnknownKeyError when the key does not exist
-   * @throws PrivateKeyStoreError when the look up could not be done
+   * @throws PrivateKeyStoreError when the look-up could not be done
    */
-  public async retrieveUnboundSessionKey(
-    keyId: Buffer,
-    privateAddress: string,
-  ): Promise<CryptoKey> {
-    const keyData = await this.retrieveSessionKeyDataOrThrowError(keyId, privateAddress);
+  public async retrieveUnboundSessionKey(keyId: Buffer, nodeId: string): Promise<CryptoKey> {
+    const keyData = await this.retrieveSessionKeyDataOrThrowError(keyId, nodeId);
 
-    if (keyData.peerPrivateAddress) {
+    if (keyData.peerId) {
       throw new UnknownKeyError(`Key ${keyId.toString('hex')} is bound`);
     }
 
@@ -92,24 +84,24 @@ export abstract class PrivateKeyStore {
    * Retrieve private session key, regardless of whether it's an initial key or not.
    *
    * @param keyId The key pair id (typically the serial number)
-   * @param privateAddress The private address of the node that owns the key
-   * @param peerPrivateAddress The private address of the recipient, in case the key is bound to
+   * @param nodeId The private address of the node that owns the key
+   * @param peerId The private address of the recipient, in case the key is bound to
    *    a recipient
    * @throws UnknownKeyError when the key does not exist
-   * @throws PrivateKeyStoreError when the look up could not be done
+   * @throws PrivateKeyStoreError when the look-up could not be done
    */
   public async retrieveSessionKey(
     keyId: Buffer,
-    privateAddress: string,
-    peerPrivateAddress: string,
+    nodeId: string,
+    peerId: string,
   ): Promise<CryptoKey> {
-    const keyData = await this.retrieveSessionKeyDataOrThrowError(keyId, privateAddress);
+    const keyData = await this.retrieveSessionKeyDataOrThrowError(keyId, nodeId);
     const keyIdHex = keyId.toString('hex');
 
-    if (keyData.peerPrivateAddress && peerPrivateAddress !== keyData.peerPrivateAddress) {
+    if (keyData.peerId && peerId !== keyData.peerId) {
       throw new UnknownKeyError(
         `Session key ${keyIdHex} is bound to another recipient ` +
-          `(${keyData.peerPrivateAddress}, not ${peerPrivateAddress})`,
+          `(${keyData.peerId}, not ${peerId})`,
       );
     }
 
@@ -118,19 +110,19 @@ export abstract class PrivateKeyStore {
 
   //endregion
 
-  public abstract saveIdentityKey(privateAddress: string, privateKey: CryptoKey): Promise<void>;
+  public abstract saveIdentityKey(nodeId: string, privateKey: CryptoKey): Promise<void>;
 
   protected abstract saveSessionKeySerialized(
     keyId: string,
     keySerialized: Buffer,
-    privateAddress: string,
-    peerPrivateAddress?: string,
+    nodeId: string,
+    peerId?: string,
   ): Promise<void>;
   protected abstract retrieveSessionKeyData(keyId: string): Promise<SessionPrivateKeyData | null>;
 
   private async retrieveSessionKeyDataOrThrowError(
     keyId: Buffer,
-    privateAddress: string,
+    nodeId: string,
   ): Promise<SessionPrivateKeyData> {
     const keyIdHex = keyId.toString('hex');
     let keyData: SessionPrivateKeyData | null;
@@ -142,7 +134,7 @@ export abstract class PrivateKeyStore {
     if (keyData === null) {
       throw new UnknownKeyError(`Key ${keyIdHex} does not exist`);
     }
-    if (keyData.privateAddress !== privateAddress) {
+    if (keyData.nodeId !== nodeId) {
       throw new UnknownKeyError('Key is owned by a different node');
     }
     return keyData;

--- a/src/lib/keyStores/PrivateKeyStore.ts
+++ b/src/lib/keyStores/PrivateKeyStore.ts
@@ -66,7 +66,7 @@ export abstract class PrivateKeyStore {
    * Return the private component of an initial session key pair.
    *
    * @param keyId The key pair id (typically the serial number)
-   * @param nodeId The private address of the node that owns the key
+   * @param nodeId The id of the node that owns the key
    * @throws UnknownKeyError when the key does not exist
    * @throws PrivateKeyStoreError when the look-up could not be done
    */
@@ -84,8 +84,8 @@ export abstract class PrivateKeyStore {
    * Retrieve private session key, regardless of whether it's an initial key or not.
    *
    * @param keyId The key pair id (typically the serial number)
-   * @param nodeId The private address of the node that owns the key
-   * @param peerId The private address of the recipient, in case the key is bound to
+   * @param nodeId The id of the node that owns the key
+   * @param peerId The id of the recipient, in case the key is bound to
    *    a recipient
    * @throws UnknownKeyError when the key does not exist
    * @throws PrivateKeyStoreError when the look-up could not be done

--- a/src/lib/keyStores/PublicKeyStore.spec.ts
+++ b/src/lib/keyStores/PublicKeyStore.spec.ts
@@ -2,7 +2,7 @@ import {
   derSerializePublicKey,
   generateECDHKeyPair,
   generateRSAKeyPair,
-  getPrivateAddressFromIdentityKey,
+  getIdFromIdentityKey,
 } from '../crypto_wrappers/keys';
 import { KeyStoreError } from './KeyStoreError';
 import { SessionPublicKeyData } from './PublicKeyStore';
@@ -19,7 +19,7 @@ describe('Identity keys', () => {
   beforeAll(async () => {
     const keyPair = await generateRSAKeyPair();
     publicKey = keyPair.publicKey;
-    peerPrivateAddress = await getPrivateAddressFromIdentityKey(publicKey);
+    peerPrivateAddress = await getIdFromIdentityKey(publicKey);
   });
 
   describe('saveIdentityKey', () => {

--- a/src/lib/keyStores/PublicKeyStore.spec.ts
+++ b/src/lib/keyStores/PublicKeyStore.spec.ts
@@ -15,21 +15,18 @@ beforeEach(() => {
 
 describe('Identity keys', () => {
   let publicKey: CryptoKey;
-  let peerPrivateAddress: string;
+  let peerId: string;
   beforeAll(async () => {
     const keyPair = await generateRSAKeyPair();
     publicKey = keyPair.publicKey;
-    peerPrivateAddress = await getIdFromIdentityKey(publicKey);
+    peerId = await getIdFromIdentityKey(publicKey);
   });
 
   describe('saveIdentityKey', () => {
     test('Key should be stored', async () => {
       await STORE.saveIdentityKey(publicKey);
 
-      expect(STORE.identityKeys).toHaveProperty(
-        peerPrivateAddress,
-        await derSerializePublicKey(publicKey),
-      );
+      expect(STORE.identityKeys).toHaveProperty(peerId, await derSerializePublicKey(publicKey));
     });
   });
 
@@ -37,7 +34,7 @@ describe('Identity keys', () => {
     test('Key should be returned if it exists', async () => {
       await STORE.saveIdentityKey(publicKey);
 
-      const publicKeyRetrieved = await STORE.retrieveIdentityKey(peerPrivateAddress);
+      const publicKeyRetrieved = await STORE.retrieveIdentityKey(peerId);
 
       await expect(derSerializePublicKey(publicKeyRetrieved!)).resolves.toEqual(
         await derSerializePublicKey(publicKey),
@@ -45,7 +42,7 @@ describe('Identity keys', () => {
     });
 
     test('Null should be returned if it does not exist', async () => {
-      await expect(STORE.retrieveIdentityKey(peerPrivateAddress)).resolves.toBeNull();
+      await expect(STORE.retrieveIdentityKey(peerId)).resolves.toBeNull();
     });
   });
 });
@@ -55,7 +52,7 @@ describe('Session keys', () => {
 
   const sessionKeyId = Buffer.from([1, 3, 5, 7, 9]);
   let sessionPublicKey: CryptoKey;
-  const peerPrivateAddress = '0deadbeef';
+  const peerId = '0deadbeef';
   beforeAll(async () => {
     const keyPair = await generateECDHKeyPair();
     sessionPublicKey = keyPair.publicKey;
@@ -68,15 +65,15 @@ describe('Session keys', () => {
         publicKeyDer: await derSerializePublicKey(sessionPublicKey),
         publicKeyId: sessionKeyId,
       };
-      STORE.registerSessionKey(keyData, peerPrivateAddress);
+      STORE.registerSessionKey(keyData, peerId);
 
-      const key = await STORE.retrieveLastSessionKey(peerPrivateAddress);
+      const key = await STORE.retrieveLastSessionKey(peerId);
       expect(key?.keyId).toEqual(sessionKeyId);
       expect(await derSerializePublicKey(key!.publicKey)).toEqual(keyData.publicKeyDer);
     });
 
     test('Null should be returned if key for recipient does not exist', async () => {
-      await expect(STORE.retrieveLastSessionKey(peerPrivateAddress)).resolves.toBeNull();
+      await expect(STORE.retrieveLastSessionKey(peerId)).resolves.toBeNull();
     });
 
     test('Retrieval errors should be wrapped', async () => {
@@ -84,7 +81,7 @@ describe('Session keys', () => {
 
       const bogusStore = new MockPublicKeyStore(false, fetchError);
 
-      await expect(bogusStore.retrieveLastSessionKey(peerPrivateAddress)).rejects.toEqual(
+      await expect(bogusStore.retrieveLastSessionKey(peerId)).rejects.toEqual(
         new KeyStoreError(fetchError, 'Failed to retrieve key'),
       );
     });
@@ -94,11 +91,11 @@ describe('Session keys', () => {
     test('Key data should be saved if there is no prior key for recipient', async () => {
       await STORE.saveSessionKey(
         { keyId: sessionKeyId, publicKey: sessionPublicKey },
-        peerPrivateAddress,
+        peerId,
         CREATION_DATE,
       );
 
-      const keyData = STORE.sessionKeys[peerPrivateAddress];
+      const keyData = STORE.sessionKeys[peerId];
       const expectedKeyData: SessionPublicKeyData = {
         publicKeyCreationTime: CREATION_DATE,
         publicKeyDer: await derSerializePublicKey(sessionPublicKey),
@@ -113,7 +110,7 @@ describe('Session keys', () => {
         publicKeyDer: await derSerializePublicKey(sessionPublicKey),
         publicKeyId: sessionKeyId,
       };
-      STORE.registerSessionKey(oldKeyData, peerPrivateAddress);
+      STORE.registerSessionKey(oldKeyData, peerId);
 
       const newPublicKeyId = Buffer.concat([sessionKeyId, Buffer.from([1, 0])]);
       const newPublicKey = (await generateECDHKeyPair()).publicKey;
@@ -121,11 +118,11 @@ describe('Session keys', () => {
       newPublicKeyDate.setHours(newPublicKeyDate.getHours() + 1);
       await STORE.saveSessionKey(
         { publicKey: newPublicKey, keyId: newPublicKeyId },
-        peerPrivateAddress,
+        peerId,
         newPublicKeyDate,
       );
 
-      const keyData = STORE.sessionKeys[peerPrivateAddress];
+      const keyData = STORE.sessionKeys[peerId];
       const expectedKeyData: SessionPublicKeyData = {
         publicKeyCreationTime: newPublicKeyDate,
         publicKeyDer: await derSerializePublicKey(newPublicKey),
@@ -140,7 +137,7 @@ describe('Session keys', () => {
         publicKeyDer: await derSerializePublicKey(sessionPublicKey),
         publicKeyId: sessionKeyId,
       };
-      STORE.registerSessionKey(currentKeyData, peerPrivateAddress);
+      STORE.registerSessionKey(currentKeyData, peerId);
 
       const olderPublicKeyId = Buffer.concat([sessionKeyId, sessionKeyId]);
       const olderPublicKey = (await generateECDHKeyPair()).publicKey;
@@ -148,11 +145,11 @@ describe('Session keys', () => {
       olderPublicKeyDate.setHours(olderPublicKeyDate.getHours() - 1);
       await STORE.saveSessionKey(
         { publicKey: olderPublicKey, keyId: olderPublicKeyId },
-        peerPrivateAddress,
+        peerId,
         olderPublicKeyDate,
       );
 
-      const keyData = STORE.sessionKeys[peerPrivateAddress];
+      const keyData = STORE.sessionKeys[peerId];
       expect(keyData).toEqual(currentKeyData);
     });
 
@@ -162,7 +159,7 @@ describe('Session keys', () => {
       await expect(
         bogusStore.saveSessionKey(
           { keyId: sessionKeyId, publicKey: sessionPublicKey },
-          peerPrivateAddress,
+          peerId,
           CREATION_DATE,
         ),
       ).rejects.toEqual(new KeyStoreError('Failed to save public session key: Denied'));

--- a/src/lib/keyStores/PublicKeyStore.ts
+++ b/src/lib/keyStores/PublicKeyStore.ts
@@ -2,7 +2,7 @@ import {
   derDeserializeECDHPublicKey,
   derDeserializeRSAPublicKey,
   derSerializePublicKey,
-  getPrivateAddressFromIdentityKey,
+  getIdFromIdentityKey,
 } from '../crypto_wrappers/keys';
 import { SessionKey } from '../SessionKey';
 import { KeyStoreError } from './KeyStoreError';
@@ -17,7 +17,7 @@ export abstract class PublicKeyStore {
   //region Identity keys
 
   public async saveIdentityKey(key: CryptoKey): Promise<void> {
-    const peerPrivateAddress = await getPrivateAddressFromIdentityKey(key);
+    const peerPrivateAddress = await getIdFromIdentityKey(key);
     const keySerialized = await derSerializePublicKey(key);
     await this.saveIdentityKeySerialized(keySerialized, peerPrivateAddress);
   }

--- a/src/lib/keyStores/PublicKeyStore.ts
+++ b/src/lib/keyStores/PublicKeyStore.ts
@@ -17,25 +17,21 @@ export abstract class PublicKeyStore {
   //region Identity keys
 
   public async saveIdentityKey(key: CryptoKey): Promise<void> {
-    const peerPrivateAddress = await getIdFromIdentityKey(key);
+    const peerId = await getIdFromIdentityKey(key);
     const keySerialized = await derSerializePublicKey(key);
-    await this.saveIdentityKeySerialized(keySerialized, peerPrivateAddress);
+    await this.saveIdentityKeySerialized(keySerialized, peerId);
   }
 
-  public async retrieveIdentityKey(peerPrivateAddress: string): Promise<CryptoKey | null> {
-    const keySerialized = await this.retrieveIdentityKeySerialized(peerPrivateAddress);
+  public async retrieveIdentityKey(peerId: string): Promise<CryptoKey | null> {
+    const keySerialized = await this.retrieveIdentityKeySerialized(peerId);
     return keySerialized ? derDeserializeRSAPublicKey(keySerialized) : null;
   }
 
   //endregion
   //region Session keys
 
-  public async saveSessionKey(
-    key: SessionKey,
-    peerPrivateAddress: string,
-    creationTime: Date,
-  ): Promise<void> {
-    const priorKeyData = await this.fetchSessionKeyDataOrWrapError(peerPrivateAddress);
+  public async saveSessionKey(key: SessionKey, peerId: string, creationTime: Date): Promise<void> {
+    const priorKeyData = await this.fetchSessionKeyDataOrWrapError(peerId);
     if (priorKeyData && creationTime <= priorKeyData.publicKeyCreationTime) {
       return;
     }
@@ -46,14 +42,14 @@ export abstract class PublicKeyStore {
       publicKeyId: key.keyId,
     };
     try {
-      await this.saveSessionKeyData(keyData, peerPrivateAddress);
+      await this.saveSessionKeyData(keyData, peerId);
     } catch (error) {
       throw new KeyStoreError(error as Error, 'Failed to save public session key');
     }
   }
 
-  public async retrieveLastSessionKey(peerPrivateAddress: string): Promise<SessionKey | null> {
-    const keyData = await this.fetchSessionKeyDataOrWrapError(peerPrivateAddress);
+  public async retrieveLastSessionKey(peerId: string): Promise<SessionKey | null> {
+    const keyData = await this.fetchSessionKeyDataOrWrapError(peerId);
     if (!keyData) {
       return null;
     }
@@ -63,27 +59,23 @@ export abstract class PublicKeyStore {
 
   //endregion
 
-  protected abstract retrieveIdentityKeySerialized(
-    peerPrivateAddress: string,
-  ): Promise<Buffer | null>;
-  protected abstract retrieveSessionKeyData(
-    peerPrivateAddress: string,
-  ): Promise<SessionPublicKeyData | null>;
+  protected abstract retrieveIdentityKeySerialized(peerId: string): Promise<Buffer | null>;
+  protected abstract retrieveSessionKeyData(peerId: string): Promise<SessionPublicKeyData | null>;
 
   protected abstract saveIdentityKeySerialized(
     keySerialized: Buffer,
-    peerPrivateAddress: string,
+    peerId: string,
   ): Promise<void>;
   protected abstract saveSessionKeyData(
     keyData: SessionPublicKeyData,
-    peerPrivateAddress: string,
+    peerId: string,
   ): Promise<void>;
 
   private async fetchSessionKeyDataOrWrapError(
-    peerPrivateAddress: string,
+    peerId: string,
   ): Promise<SessionPublicKeyData | null> {
     try {
-      return await this.retrieveSessionKeyData(peerPrivateAddress);
+      return await this.retrieveSessionKeyData(peerId);
     } catch (error) {
       throw new KeyStoreError(error as Error, 'Failed to retrieve key');
     }

--- a/src/lib/messages/CertificateRotation.spec.ts
+++ b/src/lib/messages/CertificateRotation.spec.ts
@@ -24,16 +24,16 @@ describe('CertificateRotation', () => {
       const serialization = rotation.serialize();
 
       const expectedFormatSignature = Buffer.concat([
-        Buffer.from('Relaynet'),
+        Buffer.from('Awala'),
         Buffer.from([0x10, 0x00]),
       ]);
-      expect(Buffer.from(serialization).slice(0, 10)).toEqual(expectedFormatSignature);
+      expect(Buffer.from(serialization).slice(0, 7)).toEqual(expectedFormatSignature);
     });
 
     test('Serialization should contain CertificationPath', async () => {
       const rotation = new CertificateRotation(certificationPath);
 
-      const pathSerialized = rotation.serialize().slice(10);
+      const pathSerialized = rotation.serialize().slice(7);
 
       expect(pathSerialized).toEqual(certificationPath.serialize());
     });

--- a/src/lib/messages/ParcelCollectionAck.spec.ts
+++ b/src/lib/messages/ParcelCollectionAck.spec.ts
@@ -117,8 +117,8 @@ describe('ParcelCollectionAck', () => {
 
       const pcaDeserialized = ParcelCollectionAck.deserialize(pca.serialize());
 
-      expect(pcaDeserialized.senderEndpointPrivateAddress).toEqual(SENDER_ENDPOINT_PRIVATE_ADDRESS);
-      expect(pcaDeserialized.recipientEndpointAddress).toEqual(RECIPIENT_ENDPOINT_ADDRESS);
+      expect(pcaDeserialized.senderEndpointId).toEqual(SENDER_ENDPOINT_PRIVATE_ADDRESS);
+      expect(pcaDeserialized.recipientEndpointId).toEqual(RECIPIENT_ENDPOINT_ADDRESS);
       expect(pcaDeserialized.parcelId).toEqual(PARCEL_ID);
     });
   });

--- a/src/lib/messages/ParcelCollectionAck.spec.ts
+++ b/src/lib/messages/ParcelCollectionAck.spec.ts
@@ -21,10 +21,10 @@ describe('ParcelCollectionAck', () => {
       const pcaSerialized = pca.serialize();
 
       const expectedFormatSignature = Buffer.concat([
-        Buffer.from('Relaynet'),
+        Buffer.from('Awala'),
         Buffer.from([0x51, 0x00]),
       ]);
-      expect(Buffer.from(pcaSerialized).slice(0, 10)).toEqual(expectedFormatSignature);
+      expect(Buffer.from(pcaSerialized).slice(0, 7)).toEqual(expectedFormatSignature);
     });
 
     test('An ACK should be serialized as a 3-item sequence', () => {
@@ -52,7 +52,7 @@ describe('ParcelCollectionAck', () => {
     });
 
     function skipFormatSignatureFromSerialization(pcaSerialized: ArrayBuffer): ArrayBuffer {
-      return pcaSerialized.slice(10);
+      return pcaSerialized.slice(7);
     }
 
     function parsePCA(pcaSerialized: ArrayBuffer): asn1js.Sequence {

--- a/src/lib/messages/ParcelCollectionAck.spec.ts
+++ b/src/lib/messages/ParcelCollectionAck.spec.ts
@@ -6,15 +6,15 @@ import InvalidMessageError from './InvalidMessageError';
 import { ParcelCollectionAck } from './ParcelCollectionAck';
 
 describe('ParcelCollectionAck', () => {
-  const SENDER_ENDPOINT_PRIVATE_ADDRESS = '0deadbeef';
-  const RECIPIENT_ENDPOINT_ADDRESS = 'https://example.com';
+  const SENDER_ENDPOINT_ID = '0deadbeef';
+  const RECIPIENT_ENDPOINT_INTERNET_ADDRESS = 'example.com';
   const PARCEL_ID = 'the-parcel-id';
 
   describe('serialize', () => {
     test('Serialization should start with format signature', () => {
       const pca = new ParcelCollectionAck(
-        SENDER_ENDPOINT_PRIVATE_ADDRESS,
-        RECIPIENT_ENDPOINT_ADDRESS,
+        SENDER_ENDPOINT_ID,
+        RECIPIENT_ENDPOINT_INTERNET_ADDRESS,
         PARCEL_ID,
       );
 
@@ -29,8 +29,8 @@ describe('ParcelCollectionAck', () => {
 
     test('An ACK should be serialized as a 3-item sequence', () => {
       const pca = new ParcelCollectionAck(
-        SENDER_ENDPOINT_PRIVATE_ADDRESS,
-        RECIPIENT_ENDPOINT_ADDRESS,
+        SENDER_ENDPOINT_ID,
+        RECIPIENT_ENDPOINT_INTERNET_ADDRESS,
         PARCEL_ID,
       );
 
@@ -41,10 +41,10 @@ describe('ParcelCollectionAck', () => {
       const pcaSequenceItems = pcaSequenceBlock.valueBlock.value;
       expect(pcaSequenceItems).toHaveLength(3);
       expect((pcaSequenceItems[0] as asn1js.Primitive).valueBlock.valueHex).toEqual(
-        arrayBufferFrom(SENDER_ENDPOINT_PRIVATE_ADDRESS),
+        arrayBufferFrom(SENDER_ENDPOINT_ID),
       );
       expect((pcaSequenceItems[1] as asn1js.Primitive).valueBlock.valueHex).toEqual(
-        arrayBufferFrom(RECIPIENT_ENDPOINT_ADDRESS),
+        arrayBufferFrom(RECIPIENT_ENDPOINT_INTERNET_ADDRESS),
       );
       expect((pcaSequenceItems[2] as asn1js.Primitive).valueBlock.valueHex).toEqual(
         arrayBufferFrom(PARCEL_ID),
@@ -110,15 +110,15 @@ describe('ParcelCollectionAck', () => {
 
     test('A new instance should be returned if serialization is valid', () => {
       const pca = new ParcelCollectionAck(
-        SENDER_ENDPOINT_PRIVATE_ADDRESS,
-        RECIPIENT_ENDPOINT_ADDRESS,
+        SENDER_ENDPOINT_ID,
+        RECIPIENT_ENDPOINT_INTERNET_ADDRESS,
         PARCEL_ID,
       );
 
       const pcaDeserialized = ParcelCollectionAck.deserialize(pca.serialize());
 
-      expect(pcaDeserialized.senderEndpointId).toEqual(SENDER_ENDPOINT_PRIVATE_ADDRESS);
-      expect(pcaDeserialized.recipientEndpointId).toEqual(RECIPIENT_ENDPOINT_ADDRESS);
+      expect(pcaDeserialized.senderEndpointId).toEqual(SENDER_ENDPOINT_ID);
+      expect(pcaDeserialized.recipientEndpointId).toEqual(RECIPIENT_ENDPOINT_INTERNET_ADDRESS);
       expect(pcaDeserialized.parcelId).toEqual(PARCEL_ID);
     });
   });

--- a/src/lib/messages/ParcelCollectionAck.ts
+++ b/src/lib/messages/ParcelCollectionAck.ts
@@ -16,7 +16,7 @@ export class ParcelCollectionAck {
       throw new InvalidMessageError('Format signature should be that of a PCA');
     }
 
-    const pcaSequenceSerialized = pcaSerialized.slice(10);
+    const pcaSequenceSerialized = pcaSerialized.slice(7);
     const result = verifySchema(pcaSequenceSerialized, ParcelCollectionAck.SCHEMA);
     if (!result.verified) {
       throw new InvalidMessageError('PCA did not meet required structure');

--- a/src/lib/messages/ParcelCollectionAck.ts
+++ b/src/lib/messages/ParcelCollectionAck.ts
@@ -25,28 +25,28 @@ export class ParcelCollectionAck {
     const textDecoder = new TextDecoder();
     const pcaBlock: any = (result.result as any).ParcelCollectionAck;
     return new ParcelCollectionAck(
-      textDecoder.decode(pcaBlock.senderEndpointPrivateAddress.valueBlock.valueHex),
-      textDecoder.decode(pcaBlock.recipientEndpointAddress.valueBlock.valueHex),
+      textDecoder.decode(pcaBlock.senderEndpointId.valueBlock.valueHex),
+      textDecoder.decode(pcaBlock.recipientEndpointId.valueBlock.valueHex),
       textDecoder.decode(pcaBlock.parcelId.valueBlock.valueHex),
     );
   }
 
   private static readonly SCHEMA = makeHeterogeneousSequenceSchema('ParcelCollectionAck', [
-    new Primitive({ name: 'senderEndpointPrivateAddress' }),
-    new Primitive({ name: 'recipientEndpointAddress' }),
+    new Primitive({ name: 'senderEndpointId' }),
+    new Primitive({ name: 'recipientEndpointId' }),
     new Primitive({ name: 'parcelId' }),
   ]);
 
   constructor(
-    public readonly senderEndpointPrivateAddress: string,
-    public readonly recipientEndpointAddress: string,
+    public readonly senderEndpointId: string,
+    public readonly recipientEndpointId: string,
     public readonly parcelId: string,
   ) {}
 
   public serialize(): ArrayBuffer {
     const ackSerialized = makeImplicitlyTaggedSequence(
-      new VisibleString({ value: this.senderEndpointPrivateAddress }),
-      new VisibleString({ value: this.recipientEndpointAddress }),
+      new VisibleString({ value: this.senderEndpointId }),
+      new VisibleString({ value: this.recipientEndpointId }),
       new VisibleString({ value: this.parcelId }),
     ).toBER();
     const serialization = new ArrayBuffer(

--- a/src/lib/messages/RAMFMessage.spec.ts
+++ b/src/lib/messages/RAMFMessage.spec.ts
@@ -1,5 +1,6 @@
 // tslint:disable:max-classes-per-file
 
+import { addMinutes, addSeconds, setMilliseconds, subSeconds } from 'date-fns';
 import * as jestDateMock from 'jest-date-mock';
 
 import { generateStubCert, reSerializeCertificate } from '../_test_utils';
@@ -15,6 +16,7 @@ import { StubMessage, StubPayload } from '../ramf/_test_utils';
 import RAMFError from '../ramf/RAMFError';
 import { SessionKeyPair } from '../SessionKeyPair';
 import InvalidMessageError from './InvalidMessageError';
+import { Recipient } from './Recipient';
 
 const mockStubUuid4 = '56e95d8a-6be2-4020-bb36-5dd0da36c181';
 jest.mock('uuid4', () => {
@@ -32,38 +34,24 @@ afterEach(() => {
 });
 
 describe('RAMFMessage', () => {
-  let recipientPrivateAddress: string;
-  let recipientCertificate: Certificate;
+  let rootCertificate: Certificate;
   let senderCertificate: Certificate;
+  let recipientCertificate: Certificate;
+  let recipient: Recipient;
   beforeAll(async () => {
-    const recipientKeyPair = await generateRSAKeyPair();
-    recipientCertificate = await generateStubCert({
-      attributes: { isCA: true },
-      subjectPublicKey: recipientKeyPair.publicKey,
-    });
-    recipientPrivateAddress = recipientCertificate.getCommonName();
+    const stubSenderChain = await generateAuthorizedSenderChain();
 
-    const senderKeyPair = await generateRSAKeyPair();
-    senderCertificate = reSerializeCertificate(
-      await generateStubCert({
-        subjectPublicKey: senderKeyPair.publicKey,
-      }),
-    );
-  });
+    rootCertificate = stubSenderChain.rootCert;
+    recipientCertificate = stubSenderChain.recipientCert;
+    senderCertificate = stubSenderChain.senderCert;
 
-  let stubSenderChain: AuthorizedSenderChain;
-  beforeAll(async () => {
-    stubSenderChain = await generateAuthorizedSenderChain();
+    recipient = { id: recipientCertificate.getCommonName() };
   });
 
   describe('constructor', () => {
     describe('Id', () => {
       test('Id should fall back to UUID4 when left unspecified', () => {
-        const message = new StubMessage(
-          recipientPrivateAddress,
-          senderCertificate,
-          STUB_PAYLOAD_PLAINTEXT,
-        );
+        const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT);
 
         expect(message.id).toEqual(mockStubUuid4);
       });
@@ -74,26 +62,18 @@ describe('RAMFMessage', () => {
         const now = new Date(2019, 1, 1, 1, 1, 1, 1);
         jestDateMock.advanceTo(now);
 
-        const message = new StubMessage(
-          recipientPrivateAddress,
-          senderCertificate,
-          STUB_PAYLOAD_PLAINTEXT,
-        );
+        const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT);
 
-        const expectedDate = new Date(now.getTime());
-        expectedDate.setMilliseconds(0);
+        const expectedDate = setMilliseconds(now, 0);
         expect(message.creationDate).toEqual(expectedDate);
       });
 
       test('A custom date should be accepted', () => {
         const date = new Date(2020, 1, 1, 1, 1, 1, 1);
 
-        const message = new StubMessage(
-          recipientPrivateAddress,
-          senderCertificate,
-          STUB_PAYLOAD_PLAINTEXT,
-          { creationDate: date },
-        );
+        const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT, {
+          creationDate: date,
+        });
 
         const expectedDate = new Date(date.getTime());
         expectedDate.setMilliseconds(0);
@@ -103,23 +83,16 @@ describe('RAMFMessage', () => {
 
     describe('TTL', () => {
       test('TTL should be 5 minutes by default', () => {
-        const message = new StubMessage(
-          recipientPrivateAddress,
-          senderCertificate,
-          STUB_PAYLOAD_PLAINTEXT,
-        );
+        const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT);
 
         expect(message.ttl).toEqual(5 * 60);
       });
 
       test('A custom TTL under 2^24 should be accepted', () => {
         const ttl = 2 ** 24 - 1;
-        const message = new StubMessage(
-          recipientPrivateAddress,
-          senderCertificate,
-          STUB_PAYLOAD_PLAINTEXT,
-          { ttl },
-        );
+        const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT, {
+          ttl,
+        });
 
         expect(message.ttl).toEqual(ttl);
       });
@@ -127,37 +100,25 @@ describe('RAMFMessage', () => {
 
     describe('Sender CA certificate chain', () => {
       test('CA certificate chain should be empty by default', () => {
-        const message = new StubMessage(
-          recipientPrivateAddress,
-          senderCertificate,
-          STUB_PAYLOAD_PLAINTEXT,
-        );
+        const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT);
 
         expect(message.senderCaCertificateChain).toEqual([]);
       });
 
       test('A custom sender certificate chain should be accepted', async () => {
         const chain: readonly Certificate[] = [await generateStubCert(), await generateStubCert()];
-        const message = new StubMessage(
-          recipientPrivateAddress,
-          senderCertificate,
-          STUB_PAYLOAD_PLAINTEXT,
-          { senderCaCertificateChain: chain },
-        );
+        const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT, {
+          senderCaCertificateChain: chain,
+        });
 
         expect(message.senderCaCertificateChain).toEqual(chain);
       });
 
       test('Sender certificate should be excluded from chain if included', async () => {
         const chain: readonly Certificate[] = [await generateStubCert()];
-        const message = new StubMessage(
-          recipientPrivateAddress,
-          senderCertificate,
-          STUB_PAYLOAD_PLAINTEXT,
-          {
-            senderCaCertificateChain: [...chain, senderCertificate],
-          },
-        );
+        const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT, {
+          senderCaCertificateChain: [...chain, senderCertificate],
+        });
 
         expect(message.senderCaCertificateChain).toEqual(chain);
       });
@@ -166,31 +127,26 @@ describe('RAMFMessage', () => {
 
   test('getSenderCertificationPath should return certification path', async () => {
     const message = new StubMessage(
-      await stubSenderChain.recipientCert.calculateSubjectPrivateAddress(),
-      stubSenderChain.senderCert,
+      { id: await recipientCertificate.calculateSubjectPrivateAddress() },
+      senderCertificate,
       STUB_PAYLOAD_PLAINTEXT,
       {
-        senderCaCertificateChain: [stubSenderChain.recipientCert],
+        senderCaCertificateChain: [recipientCertificate],
       },
     );
 
-    await expect(message.getSenderCertificationPath([stubSenderChain.rootCert])).resolves.toEqual([
-      expect.toSatisfy((c) => c.isEqual(stubSenderChain.senderCert)),
-      expect.toSatisfy((c) => c.isEqual(stubSenderChain.recipientCert)),
-      expect.toSatisfy((c) => c.isEqual(stubSenderChain.rootCert)),
+    await expect(message.getSenderCertificationPath([rootCertificate])).resolves.toEqual([
+      expect.toSatisfy((c) => c.isEqual(senderCertificate)),
+      expect.toSatisfy((c) => c.isEqual(recipientCertificate)),
+      expect.toSatisfy((c) => c.isEqual(rootCertificate)),
     ]);
   });
 
   test('expiryDate field should calculate expiry date from creation date and TTL', () => {
-    const message = new StubMessage(
-      'some-address',
-      stubSenderChain.senderCert,
-      STUB_PAYLOAD_PLAINTEXT,
-      {
-        creationDate: new Date('2020-04-07T21:00:00Z'),
-        ttl: 5,
-      },
-    );
+    const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT, {
+      creationDate: new Date('2020-04-07T21:00:00Z'),
+      ttl: 5,
+    });
 
     const expectedExpiryDate = new Date(message.creationDate.getTime());
     expectedExpiryDate.setSeconds(expectedExpiryDate.getSeconds() + message.ttl);
@@ -200,13 +156,11 @@ describe('RAMFMessage', () => {
   describe('validate', () => {
     describe('Authorization without trusted certificates', () => {
       test('Invalid sender certificate should be refused', async () => {
-        const validityStartDate = new Date();
-        validityStartDate.setMinutes(validityStartDate.getMinutes() + 1);
         const invalidSenderCertificate = await generateStubCert({
-          attributes: { validityStartDate },
+          attributes: { validityStartDate: addMinutes(new Date(), 1) },
         });
         const message = new StubMessage(
-          '0deadbeef',
+          recipient,
           invalidSenderCertificate,
           STUB_PAYLOAD_PLAINTEXT,
         );
@@ -215,7 +169,17 @@ describe('RAMFMessage', () => {
       });
 
       test('Valid sender certificate should be allowed', async () => {
-        const message = new StubMessage('0deadbeef', senderCertificate, STUB_PAYLOAD_PLAINTEXT);
+        const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT);
+
+        await expect(message.validate()).resolves.toBeNull();
+      });
+
+      test('Mismatching recipient should be allowed', async () => {
+        const message = new StubMessage(
+          { id: `not-${recipient.id}` },
+          senderCertificate,
+          STUB_PAYLOAD_PLAINTEXT,
+        );
 
         await expect(message.validate()).resolves.toBeNull();
       });
@@ -223,105 +187,58 @@ describe('RAMFMessage', () => {
 
     describe('Authorization with trusted certificates', () => {
       test('Message should be refused if sender is not trusted', async () => {
-        const message = new StubMessage(
-          await stubSenderChain.recipientCert.calculateSubjectPrivateAddress(),
-          senderCertificate,
-          STUB_PAYLOAD_PLAINTEXT,
-        );
+        // The intermediate certificate is missing
+        const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT);
 
-        jestDateMock.advanceBy(1_000);
-
-        await expect(message.validate([stubSenderChain.rootCert])).rejects.toEqual(
+        await expect(message.validate([rootCertificate])).rejects.toEqual(
           new InvalidMessageError('Sender is not authorized: No valid certificate paths found'),
         );
       });
 
       test('Message should be accepted if sender is trusted', async () => {
-        const message = new StubMessage(
-          await stubSenderChain.recipientCert.calculateSubjectPrivateAddress(),
-          stubSenderChain.senderCert,
-          STUB_PAYLOAD_PLAINTEXT,
-          {
-            senderCaCertificateChain: [stubSenderChain.recipientCert],
-          },
-        );
+        const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT, {
+          senderCaCertificateChain: [recipientCertificate],
+        });
 
-        jestDateMock.advanceBy(1_000);
-
-        const certificationPath = await message.validate([stubSenderChain.rootCert]);
+        const certificationPath = await message.validate([rootCertificate]);
         expect(certificationPath).toHaveLength(3);
         expect(certificationPath!![0].isEqual(message.senderCertificate)).toBeTrue();
-        expect(certificationPath!![1].isEqual(stubSenderChain.recipientCert)).toBeTrue();
-        expect(certificationPath!![2].isEqual(stubSenderChain.rootCert)).toBeTrue();
+        expect(certificationPath!![1].isEqual(recipientCertificate)).toBeTrue();
+        expect(certificationPath!![2].isEqual(rootCertificate)).toBeTrue();
       });
 
-      test('Message should be refused if recipient is private and did not authorize', async () => {
+      test('Message should be refused if recipient does not match issuer of sender', async () => {
         const message = new StubMessage(
-          '0deadbeef',
-          stubSenderChain.senderCert,
+          { id: `not-${recipient.id}` },
+          senderCertificate,
           STUB_PAYLOAD_PLAINTEXT,
           {
-            senderCaCertificateChain: [stubSenderChain.recipientCert],
+            senderCaCertificateChain: [recipientCertificate],
           },
         );
 
-        jestDateMock.advanceBy(1_000);
-
-        await expect(message.validate([stubSenderChain.rootCert])).rejects.toEqual(
-          new InvalidMessageError(`Sender is not authorized to reach ${message.recipientAddress}`),
+        await expect(message.validate([rootCertificate])).rejects.toEqual(
+          new InvalidMessageError(`Sender is not authorized to reach ${message.recipient}`),
         );
-      });
-
-      test('Message should be accepted if recipient address is public', async () => {
-        const message = new StubMessage(
-          'https://example.com',
-          stubSenderChain.senderCert,
-          STUB_PAYLOAD_PLAINTEXT,
-          {
-            senderCaCertificateChain: [stubSenderChain.recipientCert],
-          },
-        );
-
-        jestDateMock.advanceBy(1_000);
-
-        const certificationPath = await message.validate([stubSenderChain.rootCert]);
-        expect(certificationPath).toHaveLength(3);
-        expect(certificationPath!![2].isEqual(stubSenderChain.rootCert)).toBeTrue();
-        expect(certificationPath!![1].isEqual(stubSenderChain.recipientCert)).toBeTrue();
-        expect(certificationPath!![0].isEqual(message.senderCertificate)).toBeTrue();
       });
     });
 
     describe('Validity period', () => {
-      const recipientPublicAddress = 'https://example.com';
-
       test('Date equal to the current date should be accepted', async () => {
-        const stubDate = new Date(
-          senderCertificate.pkijsCertificate.notAfter.value.getTime() - 1_000,
-        );
-        stubDate.setSeconds(0, 0);
-        const message = new StubMessage(
-          recipientPublicAddress,
-          senderCertificate,
-          STUB_PAYLOAD_PLAINTEXT,
-          { creationDate: stubDate },
-        );
+        const stubDate = setMilliseconds(subSeconds(senderCertificate.expiryDate, 1), 0);
+        const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT, {
+          creationDate: stubDate,
+        });
         jestDateMock.advanceTo(stubDate);
 
         await message.validate();
       });
 
       test('Date should not be in the future', async () => {
-        const message = new StubMessage(
-          recipientPublicAddress,
-          senderCertificate,
-          STUB_PAYLOAD_PLAINTEXT,
-        );
-        message.creationDate.setMilliseconds(0);
-
-        const oneSecondAgo = new Date(message.creationDate);
-        oneSecondAgo.setDate(oneSecondAgo.getDate() - 1_000);
-        jestDateMock.advanceTo(oneSecondAgo);
+        const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT, {
+          creationDate: setMilliseconds(new Date(), 0),
+        });
+        jestDateMock.advanceTo(subSeconds(message.creationDate, 1));
 
         await expect(message.validate()).rejects.toEqual(
           new InvalidMessageError('Message date is in the future'),
@@ -329,30 +246,21 @@ describe('RAMFMessage', () => {
       });
 
       test('TTL matching current time should be accepted', async () => {
-        const message = new StubMessage(
-          recipientPublicAddress,
-          senderCertificate,
-          STUB_PAYLOAD_PLAINTEXT,
-          {
-            creationDate: senderCertificate.startDate,
-            ttl: 1,
-          },
-        );
-
+        const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT, {
+          creationDate: senderCertificate.startDate,
+          ttl: 1,
+        });
         jestDateMock.advanceTo(message.expiryDate);
 
         await message.validate();
       });
 
       test('TTL in the past should not be accepted', async () => {
-        const message = new StubMessage(
-          recipientPublicAddress,
-          senderCertificate,
-          STUB_PAYLOAD_PLAINTEXT,
-          { ttl: 1 },
-        );
+        const message = new StubMessage(recipient, senderCertificate, STUB_PAYLOAD_PLAINTEXT, {
+          ttl: 1,
+        });
+        jestDateMock.advanceTo(addSeconds(message.expiryDate, 1));
 
-        jestDateMock.advanceTo(message.creationDate.getTime() + (message.ttl + 1) * 1_000);
         await expect(message.validate()).rejects.toEqual(
           new InvalidMessageError('Message already expired'),
         );
@@ -370,7 +278,7 @@ describe('RAMFMessage', () => {
       const recipientKeyStore = new MockPrivateKeyStore();
 
       const stubMessage = new StubMessage(
-        recipientPrivateAddress,
+        recipient,
         senderCertificate,
         Buffer.from(envelopedData.serialize()),
       );
@@ -381,14 +289,14 @@ describe('RAMFMessage', () => {
       );
     });
 
-    test('Payload for private recipient should be decrypted with key store', async () => {
+    test('Payload should be decrypted with key store', async () => {
       const recipientSessionKeyPair = await SessionKeyPair.generate();
       const { envelopedData } = await SessionEnvelopedData.encrypt(
         STUB_PAYLOAD_PLAINTEXT,
         recipientSessionKeyPair.sessionKey,
       );
       const stubMessage = new StubMessage(
-        recipientPrivateAddress,
+        recipient,
         senderCertificate,
         Buffer.from(envelopedData.serialize()),
       );
@@ -396,7 +304,7 @@ describe('RAMFMessage', () => {
       await recipientKeyStore.saveSessionKey(
         recipientSessionKeyPair.privateKey,
         recipientSessionKeyPair.sessionKey.keyId,
-        stubMessage.recipientAddress,
+        recipient.id,
       );
 
       const { payload, senderSessionKey } = await stubMessage.unwrapPayload(recipientKeyStore);
@@ -407,50 +315,7 @@ describe('RAMFMessage', () => {
       expect(senderSessionKey).toEqual(await envelopedData.getOriginatorKey());
     });
 
-    test('Payload for public recipient should be decrypted with key store', async () => {
-      const recipientSessionKeyPair = await SessionKeyPair.generate();
-      const { envelopedData } = await SessionEnvelopedData.encrypt(
-        STUB_PAYLOAD_PLAINTEXT,
-        recipientSessionKeyPair.sessionKey,
-      );
-      const stubMessage = new StubMessage(
-        'https://example.com',
-        senderCertificate,
-        Buffer.from(envelopedData.serialize()),
-      );
-      const recipientKeyStore = new MockPrivateKeyStore();
-      await recipientKeyStore.saveSessionKey(
-        recipientSessionKeyPair.privateKey,
-        recipientSessionKeyPair.sessionKey.keyId,
-        recipientPrivateAddress,
-      );
-
-      const { payload, senderSessionKey } = await stubMessage.unwrapPayload(
-        recipientKeyStore,
-        recipientPrivateAddress,
-      );
-
-      expect(payload).toBeInstanceOf(StubPayload);
-      expect(Buffer.from(payload.content)).toEqual(STUB_PAYLOAD_PLAINTEXT);
-
-      expect(senderSessionKey).toEqual(await envelopedData.getOriginatorKey());
-    });
-
-    test('Recipient private address should be passed if only public is available', async () => {
-      const stubMessage = new StubMessage(
-        'https://example.com',
-        senderCertificate,
-        Buffer.from([]),
-      );
-      const recipientKeyStore = new MockPrivateKeyStore();
-
-      await expect(stubMessage.unwrapPayload(recipientKeyStore)).rejects.toThrowWithMessage(
-        RAMFError,
-        'Recipient private address should be passed because message uses public address',
-      );
-    });
-
-    test('Payload for private recipient should be decrypted with private key', async () => {
+    test('Payload should be decrypted with private key', async () => {
       const recipientSessionKeyPair = await SessionKeyPair.generate();
       const { envelopedData } = await SessionEnvelopedData.encrypt(
         STUB_PAYLOAD_PLAINTEXT,
@@ -458,7 +323,7 @@ describe('RAMFMessage', () => {
       );
 
       const stubMessage = new StubMessage(
-        '0123',
+        recipient,
         senderCertificate,
         Buffer.from(envelopedData.serialize()),
       );
@@ -467,47 +332,6 @@ describe('RAMFMessage', () => {
 
       expect(payload).toBeInstanceOf(StubPayload);
       expect(Buffer.from(payload.content)).toEqual(STUB_PAYLOAD_PLAINTEXT);
-    });
-
-    test('Payload for public recipient should be decrypted with private key', async () => {
-      const recipientSessionKeyPair = await SessionKeyPair.generate();
-      const { envelopedData } = await SessionEnvelopedData.encrypt(
-        STUB_PAYLOAD_PLAINTEXT,
-        recipientSessionKeyPair.sessionKey,
-      );
-
-      const stubMessage = new StubMessage(
-        'https://example.com',
-        senderCertificate,
-        Buffer.from(envelopedData.serialize()),
-      );
-
-      const { payload } = await stubMessage.unwrapPayload(recipientSessionKeyPair.privateKey);
-
-      expect(payload).toBeInstanceOf(StubPayload);
-      expect(Buffer.from(payload.content)).toEqual(STUB_PAYLOAD_PLAINTEXT);
-    });
-  });
-
-  describe('isRecipientAddressPrivate', () => {
-    test('True should be returned when address is private', () => {
-      const message = new StubMessage(
-        recipientPrivateAddress,
-        senderCertificate,
-        STUB_PAYLOAD_PLAINTEXT,
-      );
-
-      expect(message.isRecipientAddressPrivate).toBeTrue();
-    });
-
-    test('False should be returned when address is public', () => {
-      const message = new StubMessage(
-        'https://example.com',
-        senderCertificate,
-        STUB_PAYLOAD_PLAINTEXT,
-      );
-
-      expect(message.isRecipientAddressPrivate).toBeFalse();
     });
   });
 });

--- a/src/lib/messages/RAMFMessage.spec.ts
+++ b/src/lib/messages/RAMFMessage.spec.ts
@@ -127,7 +127,7 @@ describe('RAMFMessage', () => {
 
   test('getSenderCertificationPath should return certification path', async () => {
     const message = new StubMessage(
-      { id: await recipientCertificate.calculateSubjectPrivateAddress() },
+      { id: await recipientCertificate.calculateSubjectId() },
       senderCertificate,
       STUB_PAYLOAD_PLAINTEXT,
       {

--- a/src/lib/messages/RAMFMessage.ts
+++ b/src/lib/messages/RAMFMessage.ts
@@ -10,11 +10,8 @@ import RAMFError from '../ramf/RAMFError';
 import { SessionKey } from '../SessionKey';
 import InvalidMessageError from './InvalidMessageError';
 import PayloadPlaintext from './payloads/PayloadPlaintext';
-import { RecipientAddressType } from './RecipientAddressType';
 
 const DEFAULT_TTL_SECONDS = 5 * 60; // 5 minutes
-
-const PRIVATE_ADDRESS_REGEX = /^0[a-f\d]+$/;
 
 interface MessageOptions {
   readonly id: string;
@@ -135,17 +132,13 @@ export default abstract class RAMFMessage<Payload extends PayloadPlaintext> {
   /**
    * Report whether the message is valid.
    *
-   * @param recipientAddressType The expected type of recipient address, if one is required
-   * @param trustedCertificates If present, will check that the sender is authorized to send
+   * @param trustedCertificates? If present, will check that the sender is authorized to send
    *   the message based on the trusted certificates.
    * @return The certification path from the sender to one of the `trustedCertificates` (if present)
    */
   public async validate(
-    recipientAddressType?: RecipientAddressType,
     trustedCertificates?: readonly Certificate[],
   ): Promise<readonly Certificate[] | null> {
-    await this.validateRecipientAddress(recipientAddressType);
-
     await this.validateTiming();
 
     if (trustedCertificates) {
@@ -190,22 +183,6 @@ export default abstract class RAMFMessage<Payload extends PayloadPlaintext> {
   }
 
   protected abstract deserializePayload(payloadPlaintext: ArrayBuffer): Payload;
-
-  private async validateRecipientAddress(
-    requiredRecipientAddressType?: RecipientAddressType,
-  ): Promise<void> {
-    const isAddressPrivate = this.isRecipientAddressPrivate;
-    if (isAddressPrivate && !PRIVATE_ADDRESS_REGEX[Symbol.match](this.recipientAddress)) {
-      throw new InvalidMessageError('Recipient address is malformed');
-    }
-
-    if (requiredRecipientAddressType === RecipientAddressType.PUBLIC && isAddressPrivate) {
-      throw new InvalidMessageError('Recipient address should be public but got a private one');
-    }
-    if (requiredRecipientAddressType === RecipientAddressType.PRIVATE && !isAddressPrivate) {
-      throw new InvalidMessageError('Recipient address should be private but got a public one');
-    }
-  }
 
   private async validateAuthorization(
     trustedCertificates: readonly Certificate[],

--- a/src/lib/messages/RAMFMessage.ts
+++ b/src/lib/messages/RAMFMessage.ts
@@ -82,11 +82,6 @@ export default abstract class RAMFMessage<Payload extends PayloadPlaintext> {
     );
   }
 
-  public async unwrapPayload(privateKey: CryptoKey): Promise<PayloadUnwrapping<Payload>>;
-  public async unwrapPayload(
-    privateKeyStore: PrivateKeyStore,
-    privateAddress?: string,
-  ): Promise<PayloadUnwrapping<Payload>>;
   public async unwrapPayload(
     privateKeyOrStore: CryptoKey | PrivateKeyStore,
   ): Promise<PayloadUnwrapping<Payload>> {
@@ -140,12 +135,8 @@ export default abstract class RAMFMessage<Payload extends PayloadPlaintext> {
     const keyId = payloadEnvelopedData.getRecipientKeyId();
     let privateKey: CryptoKey;
     if (privateKeyOrStore instanceof PrivateKeyStore) {
-      const peerPrivateAddress = await this.senderCertificate.calculateSubjectPrivateAddress();
-      privateKey = await privateKeyOrStore.retrieveSessionKey(
-        keyId,
-        this.recipient.id,
-        peerPrivateAddress,
-      );
+      const peerId = await this.senderCertificate.calculateSubjectId();
+      privateKey = await privateKeyOrStore.retrieveSessionKey(keyId, this.recipient.id, peerId);
     } else {
       privateKey = privateKeyOrStore;
     }
@@ -165,7 +156,7 @@ export default abstract class RAMFMessage<Payload extends PayloadPlaintext> {
     }
 
     const recipientCertificate = certificationPath[1];
-    const recipientId = await recipientCertificate.calculateSubjectPrivateAddress();
+    const recipientId = await recipientCertificate.calculateSubjectId();
     if (recipientId !== this.recipient.id) {
       throw new InvalidMessageError(`Sender is not authorized to reach ${this.recipient}`);
     }

--- a/src/lib/messages/Recipient.ts
+++ b/src/lib/messages/Recipient.ts
@@ -1,0 +1,4 @@
+export interface Recipient {
+  readonly id: string;
+  readonly internetAddress?: string;
+}

--- a/src/lib/messages/RecipientAddressType.ts
+++ b/src/lib/messages/RecipientAddressType.ts
@@ -1,4 +1,0 @@
-export enum RecipientAddressType {
-  PRIVATE,
-  PUBLIC,
-}

--- a/src/lib/messages/_test_utils.ts
+++ b/src/lib/messages/_test_utils.ts
@@ -1,5 +1,3 @@
-/* tslint:disable:no-let */
-
 import { arrayBufferFrom, generateStubCert, getMockContext, mockSpy } from '../_test_utils';
 import { HashingAlgorithm } from '../crypto_wrappers/algorithms';
 import { generateRSAKeyPair } from '../crypto_wrappers/keys';

--- a/src/lib/messages/formatSignature.ts
+++ b/src/lib/messages/formatSignature.ts
@@ -1,11 +1,11 @@
-const SIGNATURE_PREFIX = Buffer.from('Relaynet');
+const SIGNATURE_PREFIX = Buffer.from('Awala');
 
 export function generateFormatSignature(
   concreteMessageType: number,
   concreteMessageVersion: number,
 ): Uint8Array {
-  const formatSignature = new Uint8Array(10);
+  const formatSignature = new Uint8Array(SIGNATURE_PREFIX.byteLength + 2);
   formatSignature.set(SIGNATURE_PREFIX, 0);
-  formatSignature.set([concreteMessageType, concreteMessageVersion], 8);
+  formatSignature.set([concreteMessageType, concreteMessageVersion], SIGNATURE_PREFIX.byteLength);
   return formatSignature;
 }

--- a/src/lib/messages/payloads/CargoCollectionRequest.spec.ts
+++ b/src/lib/messages/payloads/CargoCollectionRequest.spec.ts
@@ -4,7 +4,7 @@ import {
   arrayBufferFrom,
   expectArrayBuffersToEqual,
   generateStubCert,
-  getAsn1SequenceItem,
+  getPrimitiveItemFromConstructed,
 } from '../../_test_utils';
 import { makeImplicitlyTaggedSequence } from '../../asn1';
 import { derDeserialize } from '../../crypto_wrappers/_utils';
@@ -24,7 +24,7 @@ describe('serialize', () => {
     const serialization = request.serialize();
 
     const sequence = derDeserialize(serialization);
-    const cdaSerialized = getAsn1SequenceItem(sequence, 0).valueBlock.valueHex;
+    const cdaSerialized = getPrimitiveItemFromConstructed(sequence, 0).valueBlock.valueHex;
     expectArrayBuffersToEqual(cargoDeliveryAuthorization.serialize(), cdaSerialized);
   });
 });

--- a/src/lib/messages/payloads/CargoMessageSet.spec.ts
+++ b/src/lib/messages/payloads/CargoMessageSet.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:no-let no-object-mutation */
+/* tslint:disable:no-object-mutation */
 import * as asn1js from 'asn1js';
 import bufferToArray from 'buffer-to-arraybuffer';
 
@@ -97,7 +97,7 @@ describe('CargoMessageSet', () => {
     let privateKey: CryptoKey;
     let certificate: Certificate;
 
-    const PCA = new ParcelCollectionAck('https://sender.endpoint/', 'deadbeef', 'parcel-id');
+    const PCA = new ParcelCollectionAck('0deadc0de', 'deadbeef', 'parcel-id');
 
     beforeAll(async () => {
       const senderKeyPair = await generateRSAKeyPair();
@@ -109,7 +109,7 @@ describe('CargoMessageSet', () => {
     });
 
     test('Parcels should be returned', async () => {
-      const parcel = new Parcel('0deadbeef', certificate, Buffer.from('hi'));
+      const parcel = new Parcel({ id: '0deadbeef' }, certificate, Buffer.from('hi'));
       const parcelSerialization = await parcel.serialize(privateKey);
 
       const item = await CargoMessageSet.deserializeItem(parcelSerialization);
@@ -148,7 +148,7 @@ describe('CargoMessageSet', () => {
     });
 
     test('An error should be yielded when unsupported RAMF message is found', async () => {
-      const innerCargo = new Cargo('address', certificate, Buffer.from('hi'));
+      const innerCargo = new Cargo({ id: 'address' }, certificate, Buffer.from('hi'));
       const cargoSerialization = await innerCargo.serialize(privateKey);
 
       await expect(CargoMessageSet.deserializeItem(cargoSerialization)).rejects.toThrow(

--- a/src/lib/messages/payloads/CargoMessageSet.ts
+++ b/src/lib/messages/payloads/CargoMessageSet.ts
@@ -132,7 +132,7 @@ export default class CargoMessageSet implements PayloadPlaintext {
 function getItemClass(itemSerialized: ArrayBuffer): {
   readonly deserialize: (s: ArrayBuffer) => CargoMessageSetItem | Promise<CargoMessageSetItem>;
 } {
-  const messageFormatSignature = Buffer.from(itemSerialized.slice(0, 10));
+  const messageFormatSignature = Buffer.from(itemSerialized.slice(0, 7));
 
   if (messageFormatSignature.equals(ParcelCollectionAck.FORMAT_SIGNATURE)) {
     return ParcelCollectionAck;

--- a/src/lib/messages/payloads/CargoMessageSet.ts
+++ b/src/lib/messages/payloads/CargoMessageSet.ts
@@ -62,11 +62,10 @@ export default class CargoMessageSet implements PayloadPlaintext {
   public static async *batchMessagesSerialized(
     messagesWithExpiryDate: AsyncIterable<MessageWithExpiryDate>,
   ): AsyncIterable<MessageWithExpiryDate> {
-    // tslint:disable-next-line:readonly-array no-let
+    // tslint:disable-next-line:readonly-array
     let currentBatch: ArrayBuffer[] = [];
-    // tslint:disable-next-line:no-let no-unnecessary-initializer
+    // tslint:disable-next-line:no-unnecessary-initializer
     let currentBatchExpiryDate: Date | undefined = undefined;
-    // tslint:disable-next-line:no-let
     let availableOctetsInCurrentBatch = MAX_SDU_PLAINTEXT_LENGTH - DER_TL_OVERHEAD_OCTETS;
 
     for await (const { messageSerialized, expiryDate } of messagesWithExpiryDate) {

--- a/src/lib/messages/payloads/ServiceMessage.spec.ts
+++ b/src/lib/messages/payloads/ServiceMessage.spec.ts
@@ -1,7 +1,11 @@
 import * as asn1js from 'asn1js';
 import bufferToArray from 'buffer-to-arraybuffer';
 
-import { arrayBufferFrom, expectArrayBuffersToEqual, getAsn1SequenceItem } from '../../_test_utils';
+import {
+  arrayBufferFrom,
+  expectArrayBuffersToEqual,
+  getPrimitiveItemFromConstructed,
+} from '../../_test_utils';
 import { makeImplicitlyTaggedSequence } from '../../asn1';
 import { derDeserialize } from '../../crypto_wrappers/_utils';
 import InvalidMessageError from '../InvalidMessageError';
@@ -19,7 +23,7 @@ describe('ServiceMessage', () => {
 
       const sequence = derDeserialize(serialization);
       expect(sequence).toBeInstanceOf(asn1js.Sequence);
-      const typeASN1 = getAsn1SequenceItem(sequence, 0);
+      const typeASN1 = getPrimitiveItemFromConstructed(sequence, 0);
       expect(typeASN1.valueBlock.valueHex).toEqual(arrayBufferFrom(TYPE));
     });
 
@@ -30,7 +34,7 @@ describe('ServiceMessage', () => {
 
       const sequence = derDeserialize(serialization);
       expect(sequence).toBeInstanceOf(asn1js.Sequence);
-      const contentASN1 = getAsn1SequenceItem(sequence, 1);
+      const contentASN1 = getPrimitiveItemFromConstructed(sequence, 1);
       expectArrayBuffersToEqual(bufferToArray(CONTENT), contentASN1.valueBlock.valueHex);
     });
   });

--- a/src/lib/nodes/Gateway.spec.ts
+++ b/src/lib/nodes/Gateway.spec.ts
@@ -1,7 +1,7 @@
 import { addDays, setMilliseconds } from 'date-fns';
 
 import { reSerializeCertificate } from '../_test_utils';
-import { generateRSAKeyPair, getPrivateAddressFromIdentityKey } from '../crypto_wrappers/keys';
+import { generateRSAKeyPair, getIdFromIdentityKey } from '../crypto_wrappers/keys';
 import Certificate from '../crypto_wrappers/x509/Certificate';
 import { MockKeyStoreSet } from '../keyStores/testMocks';
 import { CertificationPath } from '../pki/CertificationPath';
@@ -38,7 +38,7 @@ beforeAll(async () => {
       validityEndDate: tomorrow,
     }),
   );
-  nodePrivateAddress = await getPrivateAddressFromIdentityKey(nodeKeyPair.publicKey);
+  nodePrivateAddress = await getIdFromIdentityKey(nodeKeyPair.publicKey);
 });
 
 const KEY_STORES = new MockKeyStoreSet();

--- a/src/lib/nodes/Gateway.ts
+++ b/src/lib/nodes/Gateway.ts
@@ -6,13 +6,10 @@ import { Verifier } from './signatures/Verifier';
 
 export abstract class Gateway extends Node<CargoMessageSet | CargoCollectionRequest> {
   public async getGSCVerifier<V extends Verifier>(
-    peerPrivateAddress: string,
+    peerId: string,
     verifierClass: new (trustedCertificates: readonly Certificate[]) => V,
   ): Promise<V> {
-    const trustedPaths = await this.keyStores.certificateStore.retrieveAll(
-      this.privateAddress,
-      peerPrivateAddress,
-    );
+    const trustedPaths = await this.keyStores.certificateStore.retrieveAll(this.id, peerId);
     return new verifierClass(trustedPaths.map((p) => p.leafCertificate));
   }
 }

--- a/src/lib/nodes/Node.spec.ts
+++ b/src/lib/nodes/Node.spec.ts
@@ -5,7 +5,7 @@ import { SessionEnvelopedData } from '../crypto_wrappers/cms/envelopedData';
 import {
   derSerializePublicKey,
   generateRSAKeyPair,
-  getPrivateAddressFromIdentityKey,
+  getIdFromIdentityKey,
 } from '../crypto_wrappers/keys';
 import Certificate from '../crypto_wrappers/x509/Certificate';
 import { MockKeyStoreSet } from '../keyStores/testMocks';
@@ -15,11 +15,11 @@ import { issueGatewayCertificate } from '../pki/issuance';
 import { StubMessage } from '../ramf/_test_utils';
 import { StubNode } from './_test_utils';
 
-let nodePrivateAddress: string;
+let nodeId: string;
 let nodePrivateKey: CryptoKey;
 let nodeCertificate: Certificate;
 let nodeCertificateIssuer: Certificate;
-let nodeCertificateIssuerPrivateAddress: string;
+let nodeCertificateIssuerId: string;
 beforeAll(async () => {
   const tomorrow = setMilliseconds(addDays(new Date(), 1), 0);
 
@@ -31,8 +31,7 @@ beforeAll(async () => {
       validityEndDate: tomorrow,
     }),
   );
-  nodeCertificateIssuerPrivateAddress =
-    await nodeCertificateIssuer.calculateSubjectPrivateAddress();
+  nodeCertificateIssuerId = await nodeCertificateIssuer.calculateSubjectPrivateAddress();
 
   const nodeKeyPair = await generateRSAKeyPair();
   nodePrivateKey = nodeKeyPair.privateKey;
@@ -44,7 +43,7 @@ beforeAll(async () => {
       validityEndDate: tomorrow,
     }),
   );
-  nodePrivateAddress = await getPrivateAddressFromIdentityKey(nodeKeyPair.publicKey);
+  nodeId = await getIdFromIdentityKey(nodeKeyPair.publicKey);
 });
 
 const KEY_STORES = new MockKeyStoreSet();
@@ -54,7 +53,7 @@ beforeEach(async () => {
 
 describe('getIdentityPublicKey', () => {
   test('Public key should be returned', async () => {
-    const node = new StubNode(nodePrivateAddress, nodePrivateKey, KEY_STORES, {});
+    const node = new StubNode(nodeId, nodePrivateKey, KEY_STORES, {});
 
     await expect(derSerializePublicKey(await node.getIdentityPublicKey())).resolves.toEqual(
       await derSerializePublicKey(nodePrivateKey),
@@ -64,39 +63,33 @@ describe('getIdentityPublicKey', () => {
 
 describe('getGSCSigner', () => {
   test('Nothing should be returned if certificate does not exist', async () => {
-    const node = new StubNode(nodePrivateAddress, nodePrivateKey, KEY_STORES, {});
+    const node = new StubNode(nodeId, nodePrivateKey, KEY_STORES, {});
 
     await expect(
-      node.getGSCSigner(nodeCertificateIssuerPrivateAddress, ParcelDeliverySigner),
+      node.getGSCSigner(nodeCertificateIssuerId, ParcelDeliverySigner),
     ).resolves.toBeNull();
   });
 
   test('Signer should be of the type requested if certificate exists', async () => {
-    const node = new StubNode(nodePrivateAddress, nodePrivateKey, KEY_STORES, {});
+    const node = new StubNode(nodeId, nodePrivateKey, KEY_STORES, {});
     await KEY_STORES.certificateStore.save(
       new CertificationPath(nodeCertificate, []),
-      nodeCertificateIssuerPrivateAddress,
+      nodeCertificateIssuerId,
     );
 
-    const signer = await node.getGSCSigner(
-      nodeCertificateIssuerPrivateAddress,
-      ParcelDeliverySigner,
-    );
+    const signer = await node.getGSCSigner(nodeCertificateIssuerId, ParcelDeliverySigner);
 
     expect(signer).toBeInstanceOf(ParcelDeliverySigner);
   });
 
   test('Signer should receive the certificate and private key of the node', async () => {
-    const node = new StubNode(nodePrivateAddress, nodePrivateKey, KEY_STORES, {});
+    const node = new StubNode(nodeId, nodePrivateKey, KEY_STORES, {});
     await KEY_STORES.certificateStore.save(
       new CertificationPath(nodeCertificate, []),
-      nodeCertificateIssuerPrivateAddress,
+      nodeCertificateIssuerId,
     );
 
-    const signer = await node.getGSCSigner(
-      nodeCertificateIssuerPrivateAddress,
-      ParcelDeliverySigner,
-    );
+    const signer = await node.getGSCSigner(nodeCertificateIssuerId, ParcelDeliverySigner);
 
     const plaintext = arrayBufferFrom('hiya');
     const verifier = new ParcelDeliveryVerifier([nodeCertificateIssuer]);
@@ -108,7 +101,7 @@ describe('getGSCSigner', () => {
 describe('generateSessionKey', () => {
   const PRIVATE_ADDRESS = '0deadbeef';
   test('Key should not be bound to any peer by default', async () => {
-    const node = new StubNode(nodePrivateAddress, nodePrivateKey, KEY_STORES, {});
+    const node = new StubNode(nodeId, nodePrivateKey, KEY_STORES, {});
 
     const sessionKey = await node.generateSessionKey();
 
@@ -123,7 +116,7 @@ describe('generateSessionKey', () => {
   });
 
   test('Key should be bound to a peer if explicitly set', async () => {
-    const node = new StubNode(nodePrivateAddress, nodePrivateKey, KEY_STORES, {});
+    const node = new StubNode(nodeId, nodePrivateKey, KEY_STORES, {});
     const peerPrivateAddress = `${PRIVATE_ADDRESS}cousin`;
 
     const sessionKey = await node.generateSessionKey(peerPrivateAddress);
@@ -142,11 +135,12 @@ describe('generateSessionKey', () => {
 
 describe('unwrapMessagePayload', () => {
   const PAYLOAD_PLAINTEXT_CONTENT = arrayBufferFrom('payload content');
-  const RECIPIENT_ADDRESS = 'https://example.com';
 
+  let peerId: string;
   let peerCertificate: Certificate;
   beforeAll(async () => {
     const peerKeyPair = await generateRSAKeyPair();
+    peerId = await getIdFromIdentityKey(peerKeyPair.publicKey);
     peerCertificate = await issueGatewayCertificate({
       issuerPrivateKey: peerKeyPair.privateKey,
       subjectPublicKey: peerKeyPair.publicKey,
@@ -155,14 +149,14 @@ describe('unwrapMessagePayload', () => {
   });
 
   test('Payload plaintext should be returned', async () => {
-    const node = new StubNode(nodePrivateAddress, nodePrivateKey, KEY_STORES, {});
-    const sessionKey = await node.generateSessionKey();
+    const node = new StubNode(peerId, nodePrivateKey, KEY_STORES, {});
+    const sessionKey = await node.generateSessionKey(peerId);
     const { envelopedData } = await SessionEnvelopedData.encrypt(
       PAYLOAD_PLAINTEXT_CONTENT,
       sessionKey,
     );
     const message = new StubMessage(
-      RECIPIENT_ADDRESS,
+      { id: peerId },
       peerCertificate,
       Buffer.from(envelopedData.serialize()),
     );
@@ -173,14 +167,14 @@ describe('unwrapMessagePayload', () => {
   });
 
   test('Originator session key should be stored', async () => {
-    const node = new StubNode(nodePrivateAddress, nodePrivateKey, KEY_STORES, {});
-    const sessionKey = await node.generateSessionKey();
+    const node = new StubNode(peerId, nodePrivateKey, KEY_STORES, {});
+    const sessionKey = await node.generateSessionKey(peerId);
     const { envelopedData, dhKeyId } = await SessionEnvelopedData.encrypt(
       PAYLOAD_PLAINTEXT_CONTENT,
       sessionKey,
     );
     const message = new StubMessage(
-      RECIPIENT_ADDRESS,
+      { id: peerId },
       peerCertificate,
       Buffer.from(envelopedData.serialize()),
     );

--- a/src/lib/nodes/Node.spec.ts
+++ b/src/lib/nodes/Node.spec.ts
@@ -99,7 +99,6 @@ describe('getGSCSigner', () => {
 });
 
 describe('generateSessionKey', () => {
-  const PRIVATE_ADDRESS = '0deadbeef';
   test('Key should not be bound to any peer by default', async () => {
     const node = new StubNode(nodeId, nodePrivateKey, KEY_STORES, {});
 
@@ -114,7 +113,7 @@ describe('generateSessionKey', () => {
 
   test('Key should be bound to a peer if explicitly set', async () => {
     const node = new StubNode(nodeId, nodePrivateKey, KEY_STORES, {});
-    const peerId = `${PRIVATE_ADDRESS}cousin`;
+    const peerId = '0deadbeef';
 
     const sessionKey = await node.generateSessionKey(peerId);
 

--- a/src/lib/nodes/PrivateGateway.spec.ts
+++ b/src/lib/nodes/PrivateGateway.spec.ts
@@ -28,7 +28,7 @@ let privateGatewayPDCCertificate: Certificate;
 beforeAll(async () => {
   const tomorrow = setMilliseconds(addDays(new Date(), 1), 0);
 
-  // Public gateway
+  // Internet gateway
   const internetGatewayKeyPair = await generateRSAKeyPair();
   internetGatewayPublicKey = internetGatewayKeyPair.publicKey;
   internetGatewayId = await getIdFromIdentityKey(internetGatewayPublicKey);

--- a/src/lib/nodes/PrivateGateway.spec.ts
+++ b/src/lib/nodes/PrivateGateway.spec.ts
@@ -5,7 +5,7 @@ import { PrivateNodeRegistrationRequest } from '../bindings/gsc/PrivateNodeRegis
 import {
   derSerializePublicKey,
   generateRSAKeyPair,
-  getPrivateAddressFromIdentityKey,
+  getIdFromIdentityKey,
   getRSAPublicKeyFromPrivate,
 } from '../crypto_wrappers/keys';
 import Certificate from '../crypto_wrappers/x509/Certificate';
@@ -31,7 +31,7 @@ beforeAll(async () => {
   // Public gateway
   const publicGatewayKeyPair = await generateRSAKeyPair();
   publicGatewayPublicKey = publicGatewayKeyPair.publicKey;
-  publicGatewayPrivateAddress = await getPrivateAddressFromIdentityKey(publicGatewayPublicKey);
+  publicGatewayPrivateAddress = await getIdFromIdentityKey(publicGatewayPublicKey);
   publicGatewayCertificate = reSerializeCertificate(
     await issueGatewayCertificate({
       issuerPrivateKey: publicGatewayKeyPair.privateKey,
@@ -43,9 +43,7 @@ beforeAll(async () => {
   // Private gateway
   const privateGatewayKeyPair = await generateRSAKeyPair();
   privateGatewayPrivateKey = privateGatewayKeyPair.privateKey;
-  privateGatewayPrivateAddress = await getPrivateAddressFromIdentityKey(
-    privateGatewayKeyPair.publicKey,
-  );
+  privateGatewayPrivateAddress = await getIdFromIdentityKey(privateGatewayKeyPair.publicKey);
   privateGatewayPDCCertificate = reSerializeCertificate(
     await issueGatewayCertificate({
       issuerCertificate: publicGatewayCertificate,
@@ -251,9 +249,9 @@ describe('retrievePublicGatewayChannel', () => {
       PUBLIC_GATEWAY_PUBLIC_ADDRESS,
     );
 
-    expect(channel!.publicGatewayPublicAddress).toEqual(PUBLIC_GATEWAY_PUBLIC_ADDRESS);
+    expect(channel!.publicGatewayInternetAddress).toEqual(PUBLIC_GATEWAY_PUBLIC_ADDRESS);
     expect(channel!.nodeDeliveryAuth.isEqual(privateGatewayPDCCertificate)).toBeTrue();
-    expect(channel!.peerPrivateAddress).toEqual(publicGatewayPrivateAddress);
+    expect(channel!.peerId).toEqual(publicGatewayPrivateAddress);
     await expect(derSerializePublicKey(channel!.peerPublicKey)).resolves.toEqual(
       await derSerializePublicKey(publicGatewayPublicKey),
     );

--- a/src/lib/nodes/PrivateGateway.ts
+++ b/src/lib/nodes/PrivateGateway.ts
@@ -42,35 +42,35 @@ export class PrivateGateway extends Gateway {
       throw new NodeError('Delivery authorization was not issued by public gateway');
     }
 
-    const publicGatewayPrivateAddress = deliveryAuthorization.getIssuerPrivateAddress()!;
+    const publicGatewayId = deliveryAuthorization.getIssuerId()!;
     await this.keyStores.certificateStore.save(
       new CertificationPath(deliveryAuthorization, []),
-      publicGatewayPrivateAddress,
+      publicGatewayId,
     );
     await this.keyStores.publicKeyStore.saveIdentityKey(
       await publicGatewayIdentityCertificate.getPublicKey(),
     );
     await this.keyStores.publicKeyStore.saveSessionKey(
       publicGatewaySessionPublicKey,
-      publicGatewayPrivateAddress,
+      publicGatewayId,
       new Date(),
     );
   }
 
   public async retrievePublicGatewayChannel(
-    publicGatewayPrivateAddress: string,
+    publicGatewayId: string,
     publicGatewayPublicAddress: string,
   ): Promise<PrivatePublicGatewayChannel | null> {
     const publicGatewayPublicKey = await this.keyStores.publicKeyStore.retrieveIdentityKey(
-      publicGatewayPrivateAddress,
+      publicGatewayId,
     );
     if (!publicGatewayPublicKey) {
       return null;
     }
 
     const privateGatewayDeliveryAuth = await this.keyStores.certificateStore.retrieveLatest(
-      this.privateAddress,
-      publicGatewayPrivateAddress,
+      this.id,
+      publicGatewayId,
     );
     if (!privateGatewayDeliveryAuth) {
       return null;
@@ -79,7 +79,7 @@ export class PrivateGateway extends Gateway {
     return new PrivatePublicGatewayChannel(
       this.identityPrivateKey,
       privateGatewayDeliveryAuth.leafCertificate,
-      publicGatewayPrivateAddress,
+      publicGatewayId,
       publicGatewayPublicKey,
       publicGatewayPublicAddress,
       this.keyStores,

--- a/src/lib/nodes/PrivateGateway.ts
+++ b/src/lib/nodes/PrivateGateway.ts
@@ -59,7 +59,7 @@ export class PrivateGateway extends Gateway {
 
   public async retrievePublicGatewayChannel(
     publicGatewayId: string,
-    publicGatewayPublicAddress: string,
+    publicGatewayInternetAddress: string,
   ): Promise<PrivatePublicGatewayChannel | null> {
     const publicGatewayPublicKey = await this.keyStores.publicKeyStore.retrieveIdentityKey(
       publicGatewayId,
@@ -81,7 +81,7 @@ export class PrivateGateway extends Gateway {
       privateGatewayDeliveryAuth.leafCertificate,
       publicGatewayId,
       publicGatewayPublicKey,
-      publicGatewayPublicAddress,
+      publicGatewayInternetAddress,
       this.keyStores,
       this.cryptoOptions,
     );

--- a/src/lib/nodes/PublicNodeConnectionParams.spec.ts
+++ b/src/lib/nodes/PublicNodeConnectionParams.spec.ts
@@ -29,7 +29,7 @@ beforeAll(async () => {
 });
 
 describe('serialize', () => {
-  test('Public address should be serialized', async () => {
+  test('Internet address should be serialized', async () => {
     const params = new PublicNodeConnectionParams(PUBLIC_ADDRESS, identityKey, sessionKey);
 
     const serialization = await params.serialize();
@@ -130,17 +130,17 @@ describe('deserialize', () => {
     ).rejects.toThrowWithMessage(InvalidPublicNodeConnectionParams, malformedErrorMessage);
   });
 
-  test('Public address should be syntactically valid', async () => {
-    const invalidPublicAddress = 'not a public address';
+  test('Internet address should be syntactically valid', async () => {
+    const invalidInternetAddress = 'not a domain name';
     const invalidSerialization = makeImplicitlyTaggedSequence(
-      new VisibleString({ value: invalidPublicAddress }),
+      new VisibleString({ value: invalidInternetAddress }),
       new OctetString({ valueHex: identityKeySerialized }),
       sessionKeySequence,
     ).toBER();
 
     await expect(PublicNodeConnectionParams.deserialize(invalidSerialization)).rejects.toThrow(
       new InvalidPublicNodeConnectionParams(
-        `Public address is syntactically invalid (${invalidPublicAddress})`,
+        `Internet address is syntactically invalid (${invalidInternetAddress})`,
       ),
     );
   });
@@ -207,7 +207,7 @@ describe('deserialize', () => {
 
     const paramsDeserialized = await PublicNodeConnectionParams.deserialize(serialization);
 
-    expect(paramsDeserialized.publicAddress).toEqual(PUBLIC_ADDRESS);
+    expect(paramsDeserialized.internetAddress).toEqual(PUBLIC_ADDRESS);
     await expect(derSerializePublicKey(paramsDeserialized.identityKey)).resolves.toEqual(
       Buffer.from(identityKeySerialized),
     );

--- a/src/lib/nodes/PublicNodeConnectionParams.ts
+++ b/src/lib/nodes/PublicNodeConnectionParams.ts
@@ -24,10 +24,10 @@ export class PublicNodeConnectionParams {
     const paramsASN1 = (result.result as any).PublicNodeConnectionParams;
 
     const textDecoder = new TextDecoder();
-    const publicAddress = textDecoder.decode(paramsASN1.publicAddress.valueBlock.valueHex);
-    if (!isValidDomain(publicAddress)) {
+    const internetAddress = textDecoder.decode(paramsASN1.internetAddress.valueBlock.valueHex);
+    if (!isValidDomain(internetAddress)) {
       throw new InvalidPublicNodeConnectionParams(
-        `Public address is syntactically invalid (${publicAddress})`,
+        `Internet address is syntactically invalid (${internetAddress})`,
       );
     }
 
@@ -59,14 +59,14 @@ export class PublicNodeConnectionParams {
       );
     }
 
-    return new PublicNodeConnectionParams(publicAddress, identityKey, {
+    return new PublicNodeConnectionParams(internetAddress, identityKey, {
       keyId: Buffer.from(sessionKeyId),
       publicKey: sessionPublicKey,
     });
   }
 
   private static readonly SCHEMA = makeHeterogeneousSequenceSchema('PublicNodeConnectionParams', [
-    new Primitive({ name: 'publicAddress' }),
+    new Primitive({ name: 'internetAddress' }),
     new Primitive({ name: 'identityKey' }),
     new Constructed({
       name: 'sessionKey',
@@ -78,7 +78,7 @@ export class PublicNodeConnectionParams {
   ]);
 
   constructor(
-    public readonly publicAddress: string,
+    public readonly internetAddress: string,
     public readonly identityKey: CryptoKey,
     public readonly sessionKey: SessionKey,
   ) {}
@@ -93,7 +93,7 @@ export class PublicNodeConnectionParams {
     );
 
     return makeImplicitlyTaggedSequence(
-      new VisibleString({ value: this.publicAddress }),
+      new VisibleString({ value: this.internetAddress }),
       new OctetString({ valueHex: bufferToArray(identityKeySerialized) }),
       sessionKeySequence,
     ).toBER();

--- a/src/lib/nodes/PublicNodeConnectionParams.ts
+++ b/src/lib/nodes/PublicNodeConnectionParams.ts
@@ -71,10 +71,10 @@ export class PublicNodeConnectionParams {
     new Constructed({
       name: 'sessionKey',
       value: [
-        new Primitive({ idBlock: { tagClass: 3, tagNumber: 0 } } as any),
-        new Primitive({ idBlock: { tagClass: 3, tagNumber: 1 } } as any),
+        new Primitive({ idBlock: { tagClass: 3, tagNumber: 0 } }),
+        new Primitive({ idBlock: { tagClass: 3, tagNumber: 1 } }),
       ],
-    } as any),
+    }),
   ]);
 
   constructor(

--- a/src/lib/nodes/channels/Channel.spec.ts
+++ b/src/lib/nodes/channels/Channel.spec.ts
@@ -5,10 +5,11 @@ import { SessionEnvelopedData } from '../../crypto_wrappers/cms/envelopedData';
 import {
   generateECDHKeyPair,
   generateRSAKeyPair,
-  getPrivateAddressFromIdentityKey,
+  getIdFromIdentityKey,
 } from '../../crypto_wrappers/keys';
 import Certificate from '../../crypto_wrappers/x509/Certificate';
 import { MockKeyStoreSet } from '../../keyStores/testMocks';
+import { Recipient } from '../../messages/Recipient';
 import { issueGatewayCertificate } from '../../pki/issuance';
 import { StubPayload } from '../../ramf/_test_utils';
 import { SessionKey } from '../../SessionKey';
@@ -23,7 +24,7 @@ beforeAll(async () => {
   const tomorrow = setMilliseconds(addDays(new Date(), 1), 0);
 
   const peerKeyPair = await generateRSAKeyPair();
-  peerPrivateAddress = await getPrivateAddressFromIdentityKey(peerKeyPair.publicKey);
+  peerPrivateAddress = await getIdFromIdentityKey(peerKeyPair.publicKey);
   peerPublicKey = peerKeyPair.publicKey;
   const peerCertificate = reSerializeCertificate(
     await issueGatewayCertificate({
@@ -165,7 +166,7 @@ describe('wrapMessagePayload', () => {
 });
 
 class StubChannel extends Channel {
-  async getOutboundRAMFAddress(): Promise<string> {
+  async getOutboundRAMFRecipient(): Promise<Recipient> {
     throw new Error('not implemented');
   }
 }

--- a/src/lib/nodes/channels/GatewayChannel.ts
+++ b/src/lib/nodes/channels/GatewayChannel.ts
@@ -14,12 +14,12 @@ export abstract class GatewayChannel extends Channel {
   public async *generateCargoes(messages: CargoMessageStream): AsyncIterable<Buffer> {
     const messagesAsArrayBuffers = convertBufferMessagesToArrayBuffer(messages);
     const cargoMessageSets = CargoMessageSet.batchMessagesSerialized(messagesAsArrayBuffers);
-    const recipientAddress = await this.getOutboundRAMFAddress();
+    const recipient = await this.getOutboundRAMFRecipient();
     for await (const { messageSerialized, expiryDate } of cargoMessageSets) {
       const creationDate = getCargoCreationTime();
       const ttl = getSecondsBetweenDates(creationDate, expiryDate);
       const cargo = new Cargo(
-        recipientAddress,
+        recipient,
         this.nodeDeliveryAuth,
         await this.encryptPayload(messageSerialized),
         { creationDate, ttl: Math.min(ttl, RAMF_MAX_TTL) },

--- a/src/lib/nodes/channels/PrivateGatewayChannel.spec.ts
+++ b/src/lib/nodes/channels/PrivateGatewayChannel.spec.ts
@@ -3,11 +3,12 @@ import { addDays, setMilliseconds, subMinutes, subSeconds } from 'date-fns';
 import {
   derSerializePublicKey,
   generateRSAKeyPair,
-  getPrivateAddressFromIdentityKey,
+  getIdFromIdentityKey,
   getRSAPublicKeyFromPrivate,
 } from '../../crypto_wrappers/keys';
 import Certificate from '../../crypto_wrappers/x509/Certificate';
 import { MockKeyStoreSet } from '../../keyStores/testMocks';
+import { Recipient } from '../../messages/Recipient';
 import { CertificationPath } from '../../pki/CertificationPath';
 import { issueGatewayCertificate } from '../../pki/issuance';
 import { NodeCryptoOptions } from '../NodeCryptoOptions';
@@ -22,7 +23,7 @@ beforeAll(async () => {
   // Public gateway
   const publicGatewayKeyPair = await generateRSAKeyPair();
   publicGatewayPublicKey = publicGatewayKeyPair.publicKey;
-  publicGatewayPrivateAddress = await getPrivateAddressFromIdentityKey(publicGatewayPublicKey);
+  publicGatewayPrivateAddress = await getIdFromIdentityKey(publicGatewayPublicKey);
   publicGatewayCertificate = await issueGatewayCertificate({
     issuerPrivateKey: publicGatewayKeyPair.privateKey,
     subjectPublicKey: publicGatewayPublicKey,
@@ -201,7 +202,7 @@ class StubPrivateGatewayChannel extends PrivateGatewayChannel {
     );
   }
 
-  async getOutboundRAMFAddress(): Promise<string> {
+  async getOutboundRAMFRecipient(): Promise<Recipient> {
     throw new Error('not implemented');
   }
 }

--- a/src/lib/nodes/channels/PrivateGatewayChannel.spec.ts
+++ b/src/lib/nodes/channels/PrivateGatewayChannel.spec.ts
@@ -20,7 +20,7 @@ let internetGatewayCertificate: Certificate;
 beforeAll(async () => {
   const tomorrow = setMilliseconds(addDays(new Date(), 1), 0);
 
-  // Public gateway
+  // Internet gateway
   const internetGatewayKeyPair = await generateRSAKeyPair();
   internetGatewayPublicKey = internetGatewayKeyPair.publicKey;
   internetGatewayId = await getIdFromIdentityKey(internetGatewayPublicKey);

--- a/src/lib/nodes/channels/PrivateGatewayChannel.spec.ts
+++ b/src/lib/nodes/channels/PrivateGatewayChannel.spec.ts
@@ -14,19 +14,19 @@ import { issueGatewayCertificate } from '../../pki/issuance';
 import { NodeCryptoOptions } from '../NodeCryptoOptions';
 import { PrivateGatewayChannel } from './PrivateGatewayChannel';
 
-let publicGatewayId: string;
-let publicGatewayPublicKey: CryptoKey;
-let publicGatewayCertificate: Certificate;
+let internetGatewayId: string;
+let internetGatewayPublicKey: CryptoKey;
+let internetGatewayCertificate: Certificate;
 beforeAll(async () => {
   const tomorrow = setMilliseconds(addDays(new Date(), 1), 0);
 
   // Public gateway
-  const publicGatewayKeyPair = await generateRSAKeyPair();
-  publicGatewayPublicKey = publicGatewayKeyPair.publicKey;
-  publicGatewayId = await getIdFromIdentityKey(publicGatewayPublicKey);
-  publicGatewayCertificate = await issueGatewayCertificate({
-    issuerPrivateKey: publicGatewayKeyPair.privateKey,
-    subjectPublicKey: publicGatewayPublicKey,
+  const internetGatewayKeyPair = await generateRSAKeyPair();
+  internetGatewayPublicKey = internetGatewayKeyPair.publicKey;
+  internetGatewayId = await getIdFromIdentityKey(internetGatewayPublicKey);
+  internetGatewayCertificate = await issueGatewayCertificate({
+    issuerPrivateKey: internetGatewayKeyPair.privateKey,
+    subjectPublicKey: internetGatewayPublicKey,
     validityEndDate: tomorrow,
   });
 });
@@ -41,10 +41,10 @@ beforeEach(async () => {
   // Private gateway
   privateGatewayPrivateKey = privateKey;
   privateGatewayPDCCertificate = await issueGatewayCertificate({
-    issuerCertificate: publicGatewayCertificate,
+    issuerCertificate: internetGatewayCertificate,
     issuerPrivateKey: privateKey,
     subjectPublicKey: publicKey,
-    validityEndDate: publicGatewayCertificate.expiryDate,
+    validityEndDate: internetGatewayCertificate.expiryDate,
   });
   privateGatewayId = id;
 });
@@ -192,8 +192,8 @@ class StubPrivateGatewayChannel extends PrivateGatewayChannel {
     super(
       privateGatewayPrivateKey,
       privateGatewayPDCCertificate,
-      publicGatewayId,
-      publicGatewayPublicKey,
+      internetGatewayId,
+      internetGatewayPublicKey,
       KEY_STORES,
       cryptoOptions,
     );

--- a/src/lib/nodes/channels/PrivateGatewayChannel.ts
+++ b/src/lib/nodes/channels/PrivateGatewayChannel.ts
@@ -14,12 +14,9 @@ export abstract class PrivateGatewayChannel extends GatewayChannel {
     const now = new Date();
 
     const publicKey = await getRSAPublicKeyFromPrivate(this.nodePrivateKey);
-    const privateAddress = await getIdFromIdentityKey(publicKey);
+    const nodeId = await getIdFromIdentityKey(publicKey);
 
-    const existingIssuerPath = await this.keyStores.certificateStore.retrieveLatest(
-      privateAddress,
-      privateAddress,
-    );
+    const existingIssuerPath = await this.keyStores.certificateStore.retrieveLatest(nodeId, nodeId);
     if (existingIssuerPath) {
       const minExpiryDate = addDays(now, 90);
       if (minExpiryDate <= existingIssuerPath.leafCertificate.expiryDate) {
@@ -34,7 +31,7 @@ export abstract class PrivateGatewayChannel extends GatewayChannel {
       validityStartDate: subMinutes(now, 90),
     });
     const path = new CertificationPath(issuer, []);
-    await this.keyStores.certificateStore.save(path, privateAddress);
+    await this.keyStores.certificateStore.save(path, nodeId);
     return issuer;
   }
 
@@ -43,11 +40,8 @@ export abstract class PrivateGatewayChannel extends GatewayChannel {
    */
   public async getCDAIssuers(): Promise<readonly Certificate[]> {
     const publicKey = await getRSAPublicKeyFromPrivate(this.nodePrivateKey);
-    const privateAddress = await getIdFromIdentityKey(publicKey);
-    const issuerPaths = await this.keyStores.certificateStore.retrieveAll(
-      privateAddress,
-      privateAddress,
-    );
+    const nodeId = await getIdFromIdentityKey(publicKey);
+    const issuerPaths = await this.keyStores.certificateStore.retrieveAll(nodeId, nodeId);
     return issuerPaths.map((p) => p.leafCertificate);
   }
 }

--- a/src/lib/nodes/channels/PrivateGatewayChannel.ts
+++ b/src/lib/nodes/channels/PrivateGatewayChannel.ts
@@ -1,9 +1,6 @@
 import { addDays, subMinutes } from 'date-fns';
 
-import {
-  getPrivateAddressFromIdentityKey,
-  getRSAPublicKeyFromPrivate,
-} from '../../crypto_wrappers/keys';
+import { getIdFromIdentityKey, getRSAPublicKeyFromPrivate } from '../../crypto_wrappers/keys';
 import Certificate from '../../crypto_wrappers/x509/Certificate';
 import { CertificationPath } from '../../pki/CertificationPath';
 import { issueGatewayCertificate } from '../../pki/issuance';
@@ -17,7 +14,7 @@ export abstract class PrivateGatewayChannel extends GatewayChannel {
     const now = new Date();
 
     const publicKey = await getRSAPublicKeyFromPrivate(this.nodePrivateKey);
-    const privateAddress = await getPrivateAddressFromIdentityKey(publicKey);
+    const privateAddress = await getIdFromIdentityKey(publicKey);
 
     const existingIssuerPath = await this.keyStores.certificateStore.retrieveLatest(
       privateAddress,
@@ -46,7 +43,7 @@ export abstract class PrivateGatewayChannel extends GatewayChannel {
    */
   public async getCDAIssuers(): Promise<readonly Certificate[]> {
     const publicKey = await getRSAPublicKeyFromPrivate(this.nodePrivateKey);
-    const privateAddress = await getPrivateAddressFromIdentityKey(publicKey);
+    const privateAddress = await getIdFromIdentityKey(publicKey);
     const issuerPaths = await this.keyStores.certificateStore.retrieveAll(
       privateAddress,
       privateAddress,

--- a/src/lib/nodes/channels/PrivateInternetGatewayChannel.ts
+++ b/src/lib/nodes/channels/PrivateInternetGatewayChannel.ts
@@ -16,33 +16,33 @@ const CLOCK_DRIFT_TOLERANCE_MINUTES = 90;
 const OUTBOUND_CARGO_TTL_DAYS = 14;
 
 /**
- * Channel between a private gateway (the node) and its public gateway (the peer).
+ * Channel between a private gateway (the node) and its Internet gateway (the peer).
  */
-export class PrivatePublicGatewayChannel extends PrivateGatewayChannel {
+export class PrivateInternetGatewayChannel extends PrivateGatewayChannel {
   /**
    * @internal
    */
   constructor(
     privateGatewayPrivateKey: CryptoKey,
     privateGatewayDeliveryAuth: Certificate,
-    publicGatewayId: string,
-    publicGatewayPublicKey: CryptoKey,
-    public readonly publicGatewayInternetAddress: string,
+    internetGatewayId: string,
+    internetGatewayPublicKey: CryptoKey,
+    public readonly internetGatewayInternetAddress: string,
     keyStores: KeyStoreSet,
     cryptoOptions: Partial<NodeCryptoOptions>,
   ) {
     super(
       privateGatewayPrivateKey,
       privateGatewayDeliveryAuth,
-      publicGatewayId,
-      publicGatewayPublicKey,
+      internetGatewayId,
+      internetGatewayPublicKey,
       keyStores,
       cryptoOptions,
     );
   }
 
   async getOutboundRAMFRecipient(): Promise<Recipient> {
-    return { id: this.peerId, internetAddress: this.publicGatewayInternetAddress };
+    return { id: this.peerId, internetAddress: this.internetGatewayInternetAddress };
   }
 
   //region Private endpoint registration
@@ -94,7 +94,7 @@ export class PrivatePublicGatewayChannel extends PrivateGatewayChannel {
     const registration = new PrivateNodeRegistration(
       endpointCertificate,
       this.nodeDeliveryAuth,
-      this.publicGatewayInternetAddress,
+      this.internetGatewayInternetAddress,
     );
     return registration.serialize();
   }

--- a/src/lib/nodes/channels/PrivatePublicGatewayChannel.spec.ts
+++ b/src/lib/nodes/channels/PrivatePublicGatewayChannel.spec.ts
@@ -204,6 +204,14 @@ describe('Endpoint registration', () => {
       expect(registration.gatewayCertificate.isEqual(privateGatewayPDCCertificate)).toBeTrue();
     });
 
+    test('Public gateway public gateway should be included in registration', async () => {
+      const registrationSerialized = await channel.registerEndpoint(endpointPublicKey);
+
+      const registration = await PrivateNodeRegistration.deserialize(registrationSerialized);
+
+      expect(registration.publicGatewayPublicAddress).toEqual(PUBLIC_GATEWAY_PUBLIC_ADDRESS);
+    });
+
     test('Session key should be absent from registration', async () => {
       const registrationSerialized = await channel.registerEndpoint(endpointPublicKey);
 

--- a/src/lib/nodes/channels/PrivatePublicGatewayChannel.spec.ts
+++ b/src/lib/nodes/channels/PrivatePublicGatewayChannel.spec.ts
@@ -83,7 +83,7 @@ beforeEach(() => {
   );
 });
 
-test('getOutboundRAMFAddress should return public address of public gateway', async () => {
+test('getOutboundRAMFAddress should return Internet address of public gateway', async () => {
   await expect(channel.getOutboundRAMFRecipient()).resolves.toEqual<Recipient>({
     id: publicGatewayId,
     internetAddress: PUBLIC_GATEWAY_INTERNET_ADDRESS,
@@ -209,7 +209,7 @@ describe('Endpoint registration', () => {
 
       const registration = await PrivateNodeRegistration.deserialize(registrationSerialized);
 
-      expect(registration.publicGatewayPublicAddress).toEqual(PUBLIC_GATEWAY_INTERNET_ADDRESS);
+      expect(registration.publicGatewayInternetAddress).toEqual(PUBLIC_GATEWAY_INTERNET_ADDRESS);
     });
 
     test('Session key should be absent from registration', async () => {

--- a/src/lib/nodes/channels/PrivatePublicGatewayChannel.spec.ts
+++ b/src/lib/nodes/channels/PrivatePublicGatewayChannel.spec.ts
@@ -27,7 +27,7 @@ let privateGatewayPDCCertificate: Certificate;
 beforeAll(async () => {
   const nextYear = setMilliseconds(addDays(new Date(), 360), 0);
 
-  // Public gateway
+  // Internet gateway
   const internetGatewayKeyPair = await generateRSAKeyPair();
   internetGatewayPublicKey = internetGatewayKeyPair.publicKey;
   internetGatewayId = await getIdFromIdentityKey(internetGatewayPublicKey);
@@ -204,7 +204,7 @@ describe('Endpoint registration', () => {
       expect(registration.gatewayCertificate.isEqual(privateGatewayPDCCertificate)).toBeTrue();
     });
 
-    test('Public gateway Internet gateway should be included in registration', async () => {
+    test('Internet gateway Internet gateway should be included in registration', async () => {
       const registrationSerialized = await channel.registerEndpoint(endpointPublicKey);
 
       const registration = await PrivateNodeRegistration.deserialize(registrationSerialized);

--- a/src/lib/nodes/channels/PrivatePublicGatewayChannel.ts
+++ b/src/lib/nodes/channels/PrivatePublicGatewayChannel.ts
@@ -90,7 +90,11 @@ export class PrivatePublicGatewayChannel extends PrivateGatewayChannel {
       subjectPublicKey: endpointPublicKey,
       validityEndDate: addMonths(new Date(), 6),
     });
-    const registration = new PrivateNodeRegistration(endpointCertificate, this.nodeDeliveryAuth);
+    const registration = new PrivateNodeRegistration(
+      endpointCertificate,
+      this.nodeDeliveryAuth,
+      this.publicGatewayPublicAddress,
+    );
     return registration.serialize();
   }
 

--- a/src/lib/nodes/channels/PrivatePublicGatewayChannel.ts
+++ b/src/lib/nodes/channels/PrivatePublicGatewayChannel.ts
@@ -25,7 +25,7 @@ export class PrivatePublicGatewayChannel extends PrivateGatewayChannel {
   constructor(
     privateGatewayPrivateKey: CryptoKey,
     privateGatewayDeliveryAuth: Certificate,
-    publicGatewayPrivateAddress: string,
+    publicGatewayId: string,
     publicGatewayPublicKey: CryptoKey,
     public readonly publicGatewayInternetAddress: string,
     keyStores: KeyStoreSet,
@@ -34,7 +34,7 @@ export class PrivatePublicGatewayChannel extends PrivateGatewayChannel {
     super(
       privateGatewayPrivateKey,
       privateGatewayDeliveryAuth,
-      publicGatewayPrivateAddress,
+      publicGatewayId,
       publicGatewayPublicKey,
       keyStores,
       cryptoOptions,

--- a/src/lib/nodes/managers/EndpointManager.spec.ts
+++ b/src/lib/nodes/managers/EndpointManager.spec.ts
@@ -9,10 +9,10 @@ afterEach(() => {
 
 describe('get', () => {
   test('Endpoint instances should be returned', async () => {
-    const { privateAddress } = await KEY_STORES.privateKeyStore.generateIdentityKeyPair();
+    const { id } = await KEY_STORES.privateKeyStore.generateIdentityKeyPair();
     const manager = new EndpointManager(KEY_STORES);
 
-    const endpoint = await manager.get(privateAddress);
+    const endpoint = await manager.get(id);
 
     expect(endpoint).toBeInstanceOf(Endpoint);
   });

--- a/src/lib/nodes/managers/NodeConstructor.ts
+++ b/src/lib/nodes/managers/NodeConstructor.ts
@@ -3,7 +3,7 @@ import { NodeCryptoOptions } from '../NodeCryptoOptions';
 import { Node } from '../Node';
 
 export type NodeConstructor<N extends Node<any>> = new (
-  privateAddress: string,
+  id: string,
   identityPrivateKey: CryptoKey,
   keyStores: KeyStoreSet,
   cryptoOptions: Partial<NodeCryptoOptions>,

--- a/src/lib/nodes/managers/NodeManager.spec.ts
+++ b/src/lib/nodes/managers/NodeManager.spec.ts
@@ -18,21 +18,20 @@ describe('get', () => {
   });
 
   test('Node should be returned if private key exists', async () => {
-    const { privateKey, privateAddress } =
-      await KEY_STORES.privateKeyStore.generateIdentityKeyPair();
+    const { privateKey, id } = await KEY_STORES.privateKeyStore.generateIdentityKeyPair();
     const manager = new StubNodeManager(KEY_STORES);
 
-    const gateway = await manager.get(privateAddress);
+    const gateway = await manager.get(id);
 
-    expect(MOCK_NODE_CLASS).toBeCalledWith(privateAddress, privateKey, KEY_STORES, {});
+    expect(MOCK_NODE_CLASS).toBeCalledWith(id, privateKey, KEY_STORES, {});
     expect(gateway).toEqual(MOCK_NODE_CLASS.mock.instances[0]);
   });
 
   test('Key stores should be passed on', async () => {
-    const { privateAddress } = await KEY_STORES.privateKeyStore.generateIdentityKeyPair();
+    const { id } = await KEY_STORES.privateKeyStore.generateIdentityKeyPair();
     const manager = new StubNodeManager(KEY_STORES);
 
-    await manager.get(privateAddress);
+    await manager.get(id);
 
     expect(MOCK_NODE_CLASS).toBeCalledWith(
       expect.anything(),
@@ -43,11 +42,11 @@ describe('get', () => {
   });
 
   test('Crypto options should be honoured if passed', async () => {
-    const { privateAddress } = await KEY_STORES.privateKeyStore.generateIdentityKeyPair();
+    const { id } = await KEY_STORES.privateKeyStore.generateIdentityKeyPair();
     const cryptoOptions = { encryption: { aesKeySize: 256 } };
     const manager = new StubNodeManager(KEY_STORES, cryptoOptions);
 
-    await manager.get(privateAddress);
+    await manager.get(id);
 
     expect(MOCK_NODE_CLASS).toBeCalledWith(
       expect.anything(),
@@ -61,17 +60,11 @@ describe('get', () => {
     const customPrivateGateway = {};
     const customPrivateGatewayConstructor = jest.fn().mockReturnValue(customPrivateGateway);
     const manager = new StubNodeManager(KEY_STORES);
-    const { privateKey, privateAddress } =
-      await KEY_STORES.privateKeyStore.generateIdentityKeyPair();
+    const { privateKey, id } = await KEY_STORES.privateKeyStore.generateIdentityKeyPair();
 
-    const gateway = await manager.get(privateAddress, customPrivateGatewayConstructor);
+    const gateway = await manager.get(id, customPrivateGatewayConstructor);
 
     expect(gateway).toBe(customPrivateGateway);
-    expect(customPrivateGatewayConstructor).toBeCalledWith(
-      privateAddress,
-      privateKey,
-      KEY_STORES,
-      {},
-    );
+    expect(customPrivateGatewayConstructor).toBeCalledWith(id, privateKey, KEY_STORES, {});
   });
 });

--- a/src/lib/nodes/managers/NodeManager.ts
+++ b/src/lib/nodes/managers/NodeManager.ts
@@ -12,30 +12,24 @@ export abstract class NodeManager<N extends Node<any>> {
   ) {}
 
   /**
-   * Get node by `privateAddress`.
+   * Get node by `id`.
    *
-   * @param privateAddress
+   * @param id
    */
-  public async get(privateAddress: string): Promise<N | null>;
+  public async get(id: string): Promise<N | null>;
   /**
-   * Get node by `privateAddress` but return instance of custom `customNodeClass`.
+   * Get node by `id` but return instance of custom `customNodeClass`.
    *
-   * @param privateAddress
+   * @param id
    * @param customNodeClass
    */
-  public async get<C extends N>(
-    privateAddress: string,
-    customNodeClass: NodeConstructor<C>,
-  ): Promise<C | null>;
-  public async get(
-    privateAddress: string,
-    nodeConstructor?: NodeConstructor<N>,
-  ): Promise<N | null> {
-    const nodePrivateKey = await this.keyStores.privateKeyStore.retrieveIdentityKey(privateAddress);
+  public async get<C extends N>(id: string, customNodeClass: NodeConstructor<C>): Promise<C | null>;
+  public async get(id: string, nodeConstructor?: NodeConstructor<N>): Promise<N | null> {
+    const nodePrivateKey = await this.keyStores.privateKeyStore.retrieveIdentityKey(id);
     if (!nodePrivateKey) {
       return null;
     }
     const constructor = nodeConstructor ?? this.defaultNodeConstructor;
-    return new constructor(privateAddress, nodePrivateKey, this.keyStores, this.cryptoOptions);
+    return new constructor(id, nodePrivateKey, this.keyStores, this.cryptoOptions);
   }
 }

--- a/src/lib/nodes/managers/PrivateGatewayManager.spec.ts
+++ b/src/lib/nodes/managers/PrivateGatewayManager.spec.ts
@@ -9,10 +9,10 @@ afterEach(() => {
 
 describe('get', () => {
   test('PrivateGateway instances should be returned', async () => {
-    const { privateAddress } = await KEY_STORES.privateKeyStore.generateIdentityKeyPair();
+    const { id } = await KEY_STORES.privateKeyStore.generateIdentityKeyPair();
     const manager = new PrivateGatewayManager(KEY_STORES);
 
-    const gateway = await manager.get(privateAddress);
+    const gateway = await manager.get(id);
 
     expect(gateway).toBeInstanceOf(PrivateGateway);
   });

--- a/src/lib/pki/issuance.spec.ts
+++ b/src/lib/pki/issuance.spec.ts
@@ -65,7 +65,7 @@ describe('issueGatewayCertificate', () => {
     expect(mockCertificateIssue.mock.calls[0][0]).toMatchObject(basicCertificateOptions);
   });
 
-  test('Certificate should have its private address as its Common Name (CN)', async () => {
+  test('Certificate should have its id as its Common Name (CN)', async () => {
     await issueGatewayCertificate(minimalCertificateOptions);
 
     expect(mockCertificateIssue.mock.calls[0][0]).toHaveProperty(
@@ -121,7 +121,7 @@ describe('issueEndpointCertificate', () => {
     expect(mockCertificateIssue.mock.calls[0][0]).toMatchObject(basicCertificateOptions);
   });
 
-  test('Certificate should have its private address as its Common Name (CN)', async () => {
+  test('Certificate should have its id as its Common Name (CN)', async () => {
     await issueEndpointCertificate(minimalCertificateOptions);
 
     expect(mockCertificateIssue.mock.calls[0][0]).toHaveProperty(
@@ -192,7 +192,7 @@ describe('issueDeliveryAuthorization', () => {
     expect(mockCertificateIssue.mock.calls[0][0]).toMatchObject(basicCertificateOptions);
   });
 
-  test('Certificate should have its private address as its Common Name (CN)', async () => {
+  test('Certificate should have its id as its Common Name (CN)', async () => {
     await issueDeliveryAuthorization(minimalCertificateOptions);
 
     expect(mockCertificateIssue.mock.calls[0][0]).toHaveProperty(

--- a/src/lib/ramf/serialization.spec.ts
+++ b/src/lib/ramf/serialization.spec.ts
@@ -818,7 +818,7 @@ describe('MessageSerializer', () => {
               StubMessage,
             ),
           ).rejects.toEqual(
-            new RAMFSyntaxError('Recipient SEQUENCE should at least contain the private address'),
+            new RAMFSyntaxError('Recipient SEQUENCE should at least contain the id'),
           );
         });
 

--- a/src/lib/ramf/serialization.spec.ts
+++ b/src/lib/ramf/serialization.spec.ts
@@ -929,7 +929,7 @@ describe('MessageSerializer', () => {
 
         test('Date not serialized as an ASN.1 DATE-TIME should be refused', async () => {
           const messageSerialized = await serializeRamfWithoutValidation([
-            new VisibleString({ value: 'the-address' }),
+            new Sequence({ value: [new VisibleString({ value: 'the-address' })] }),
             new VisibleString({ value: 'id' }),
             new DateTime({ value: '42' }),
             new Integer({ value: 1_000 }),
@@ -943,9 +943,7 @@ describe('MessageSerializer', () => {
               stubConcreteMessageVersionOctet,
               StubMessage,
             ),
-          ).rejects.toMatchObject({
-            message: /^Message date is invalid:/,
-          });
+          ).rejects.toThrowWithMessage(RAMFValidationError, /^Message date is invalid:/);
         });
       });
 

--- a/src/lib/ramf/serialization.spec.ts
+++ b/src/lib/ramf/serialization.spec.ts
@@ -252,10 +252,8 @@ describe('MessageSerializer', () => {
 
             const fields = await deserializeFields(messageSerialized);
             const recipientASN1 = getConstructedItemFromConstructed(fields, 0);
-            const privateAddressASN1 = getPrimitiveItemFromConstructed(recipientASN1, 0);
-            expect(Buffer.from(privateAddressASN1.valueBlock.valueHexView)).toEqual(
-              Buffer.from(RECIPIENT_ID),
-            );
+            const idASN1 = getPrimitiveItemFromConstructed(recipientASN1, 0);
+            expect(Buffer.from(idASN1.valueBlock.valueHexView)).toEqual(Buffer.from(RECIPIENT_ID));
           });
 
           test('Id should not span more than 1024 characters', async () => {
@@ -310,8 +308,8 @@ describe('MessageSerializer', () => {
 
             const fields = await deserializeFields(messageSerialized);
             const recipientASN1 = getConstructedItemFromConstructed(fields, 0);
-            const privateAddressASN1 = getPrimitiveItemFromConstructed(recipientASN1, 1);
-            expect(Buffer.from(privateAddressASN1.valueBlock.valueHexView)).toEqual(
+            const idASN1 = getPrimitiveItemFromConstructed(recipientASN1, 1);
+            expect(Buffer.from(idASN1.valueBlock.valueHexView)).toEqual(
               Buffer.from(INTERNET_ADDRESS),
             );
           });

--- a/src/lib/ramf/serialization.spec.ts
+++ b/src/lib/ramf/serialization.spec.ts
@@ -87,7 +87,7 @@ describe('MessageSerializer', () => {
         stubMessage = new StubMessage(RECIPIENT, senderCertificate, PAYLOAD);
       });
 
-      test('The ASCII string "Relaynet" should be at the start', async () => {
+      test('The ASCII string "Awala" should be at the start', async () => {
         const messageSerialized = await serialize(
           stubMessage,
           stubConcreteMessageTypeOctet,
@@ -95,7 +95,7 @@ describe('MessageSerializer', () => {
           senderPrivateKey,
         );
         const formatSignature = parseFormatSignature(messageSerialized);
-        expect(formatSignature).toHaveProperty('magic', 'Relaynet');
+        expect(formatSignature).toHaveProperty('magic', 'Awala');
       });
 
       test('The concrete message type should be represented with an octet', async () => {
@@ -521,7 +521,7 @@ describe('MessageSerializer', () => {
 
       async function deserializeFields(messageSerialized: ArrayBuffer): Promise<Sequence> {
         // Skip format signature
-        const cmsSignedDataSerialized = messageSerialized.slice(10);
+        const cmsSignedDataSerialized = messageSerialized.slice(7);
         const { plaintext } = await cmsSignedData.verifySignature(cmsSignedDataSerialized);
         return derDeserialize(plaintext) as Sequence;
       }
@@ -544,7 +544,7 @@ describe('MessageSerializer', () => {
         ),
       ).rejects.toThrowWithMessage(
         RAMFSyntaxError,
-        'RAMF format signature does not begin with "Relaynet"',
+        'RAMF format signature does not begin with "Awala"',
       );
     });
 
@@ -566,7 +566,7 @@ describe('MessageSerializer', () => {
 
     describe('Format signature', () => {
       test('Input should be long enough to contain format signature', async () => {
-        const serialization = bufferToArray(Buffer.from('a'.repeat(9)));
+        const serialization = bufferToArray(Buffer.from('a'.repeat(6)));
         await expect(
           deserialize(
             serialization,
@@ -580,7 +580,7 @@ describe('MessageSerializer', () => {
         );
       });
 
-      test('Input should be refused if it does not start with "Relaynet"', async () => {
+      test('Input should be refused if it does not start with "Awala"', async () => {
         const serialization = bufferToArray(Buffer.from('Relaycorp00'));
         await expect(
           deserialize(
@@ -591,7 +591,7 @@ describe('MessageSerializer', () => {
           ),
         ).rejects.toThrowWithMessage(
           RAMFSyntaxError,
-          'RAMF format signature does not begin with "Relaynet"',
+          'RAMF format signature does not begin with "Awala"',
         );
       });
 
@@ -714,7 +714,7 @@ describe('MessageSerializer', () => {
     describe('Fields', () => {
       test('Fields should be DER-encoded', async () => {
         const serializer = new SmartBuffer();
-        serializer.writeString('Relaynet');
+        serializer.writeString('Awala');
         serializer.writeUInt8(stubConcreteMessageTypeOctet);
         serializer.writeUInt8(stubConcreteMessageVersionOctet);
         serializer.writeBuffer(
@@ -740,7 +740,7 @@ describe('MessageSerializer', () => {
 
       test('Fields should be serialized as a sequence', async () => {
         const serializer = new SmartBuffer();
-        serializer.writeString('Relaynet');
+        serializer.writeString('Awala');
         serializer.writeUInt8(stubConcreteMessageTypeOctet);
         serializer.writeUInt8(stubConcreteMessageVersionOctet);
 
@@ -1172,7 +1172,7 @@ describe('MessageSerializer', () => {
       customSenderCertificate?: Certificate,
     ): Promise<ArrayBuffer> {
       const serializer = new SmartBuffer();
-      serializer.writeString('Relaynet');
+      serializer.writeString('Awala');
       serializer.writeUInt8(stubConcreteMessageTypeOctet);
       serializer.writeUInt8(stubConcreteMessageVersionOctet);
 
@@ -1197,8 +1197,8 @@ interface MessageFormatSignature {
 function parseFormatSignature(messageSerialized: ArrayBuffer): MessageFormatSignature {
   const buffer = Buffer.from(messageSerialized);
   return {
-    concreteMessageType: buffer.readUInt8(8),
-    concreteMessageVersion: buffer.readUInt8(9),
-    magic: buffer.slice(0, 8).toString(),
+    concreteMessageType: buffer.readUInt8(5),
+    concreteMessageVersion: buffer.readUInt8(6),
+    magic: buffer.slice(0, 5).toString(),
   };
 }

--- a/src/lib/ramf/serialization.ts
+++ b/src/lib/ramf/serialization.ts
@@ -36,7 +36,7 @@ const MAX_ID_LENGTH = 64;
 export const RAMF_MAX_TTL = 15552000;
 const MAX_PAYLOAD_LENGTH = 2 ** 23 - 1; // 8 MiB
 
-const PRIVATE_ADDRESS_REGEX = /^[a-f\d]+$/;
+const NODE_ID_REGEX = /^[a-f\d]+$/;
 
 /**
  * Maximum length of any SDU to be encapsulated in a CMS EnvelopedData value, per the RAMF spec.
@@ -212,7 +212,7 @@ function validateFileFormatSignature(
 function validateRecipient(recipient: Recipient): void {
   validateRecipientFieldsLength(recipient);
 
-  if (!recipient.id.match(PRIVATE_ADDRESS_REGEX)) {
+  if (!recipient.id.match(NODE_ID_REGEX)) {
     throw new RAMFSyntaxError(`Recipient id is malformed ("${recipient.id}")`);
   }
 
@@ -292,7 +292,7 @@ function parseMessageFields(serialization: ArrayBuffer): MessageFieldSet {
 
   const recipientSequence = messageBlock.recipient.valueBlock.value;
   if (recipientSequence.length === 0) {
-    throw new RAMFSyntaxError('Recipient SEQUENCE should at least contain the private address');
+    throw new RAMFSyntaxError('Recipient SEQUENCE should at least contain the id');
   }
   const recipientId = textDecoder.decode(recipientSequence[0].valueBlock.valueHex);
   const recipientInternetAddress =


### PR DESCRIPTION
Part of https://github.com/relaycorp/relayverse/issues/19

- [x] Implement `RecipientAddressing` class.
- [x] Reimplement `RAMFMessage.recipient` as a `RecipientAddressing`
- [x] Remove `RAMFMessage.isRecipientAddressPrivate`
- [x] Remove `https://` prefix from Internet addresses.