### PR TITLE
fix: Rename `PublicNodeConnectionParams` to `NodeConnectionParams`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,6 @@ export { PrivateInternetGatewayChannel } from './lib/nodes/channels/PrivateInter
 //endregion
 
 export { NodeCryptoOptions } from './lib/nodes/NodeCryptoOptions';
-export { PublicNodeConnectionParams } from './lib/nodes/PublicNodeConnectionParams';
+export { NodeConnectionParams } from './lib/nodes/NodeConnectionParams';
 export * from './lib/nodes/errors';
 export * from './lib/internetAddressing';

--- a/src/lib/crypto_wrappers/x509/Certificate.spec.ts
+++ b/src/lib/crypto_wrappers/x509/Certificate.spec.ts
@@ -128,27 +128,17 @@ describe('issue()', () => {
   });
 
   test('should generate a positive serial number', async () => {
-    let anySignFlipped = false;
     for (let index = 0; index < 10; index++) {
       const cert = await Certificate.issue({
         ...baseCertificateOptions,
         issuerPrivateKey: subjectKeyPair.privateKey,
         subjectPublicKey: subjectKeyPair.publicKey,
       });
-      const serialNumberSerialized = new Uint8Array(
-        cert.pkijsCertificate.serialNumber.valueBlock.valueHex,
-      );
-      if (serialNumberSerialized.length === 9) {
-        expect(serialNumberSerialized[0]).toEqual(0);
-        anySignFlipped = true;
-      } else {
-        expect(serialNumberSerialized).toHaveLength(8);
-        expect(serialNumberSerialized[0]).toBeGreaterThanOrEqual(0);
-        expect(serialNumberSerialized[0]).toBeLessThanOrEqual(127);
-      }
+      const serialNumberSerialized = cert.pkijsCertificate.serialNumber.valueBlock.valueHexView;
+      expect(serialNumberSerialized).toHaveLength(8);
+      expect(serialNumberSerialized[0]).toBeGreaterThanOrEqual(0);
+      expect(serialNumberSerialized[0]).toBeLessThanOrEqual(127);
     }
-
-    expect(anySignFlipped).toBeTrue();
   });
 
   test('should create a certificate valid from now by default', async () => {

--- a/src/lib/crypto_wrappers/x509/Certificate.ts
+++ b/src/lib/crypto_wrappers/x509/Certificate.ts
@@ -280,19 +280,14 @@ export default class Certificate {
 }
 
 function generatePositiveASN1Integer(): Integer {
-  const signedInteger = new Uint8Array(generateRandom64BitValue());
+  const potentiallySignedInteger = new Uint8Array(generateRandom64BitValue());
 
-  let unsignedInteger = signedInteger;
-  if (127 < signedInteger[0]) {
-    // The integer is negative, so let's flip the sign by prepending a 0x00 octet. See:
-    // https://docs.microsoft.com/en-us/windows/win32/seccertenroll/about-integer
-    unsignedInteger = new Uint8Array(signedInteger.byteLength + 1);
-    unsignedInteger.set(signedInteger, 1); // Skip the first octet, leaving it as 0x00
-  }
+  // ASN.1 BER/DER INTEGER uses two's complement with big endian, so we ensure the integer is
+  // positive by keeping the leftmost octet below 128.
+  const unsignedInteger = new Uint8Array(potentiallySignedInteger);
+  unsignedInteger.set([Math.min(potentiallySignedInteger[0], 127)], 0);
 
-  return new Integer({
-    valueHex: unsignedInteger,
-  } as any);
+  return new Integer({ valueHex: unsignedInteger });
 }
 
 //region Extensions

--- a/src/lib/crypto_wrappers/x509/Certificate.ts
+++ b/src/lib/crypto_wrappers/x509/Certificate.ts
@@ -284,10 +284,10 @@ function generatePositiveASN1Integer(): Integer {
 
   // ASN.1 BER/DER INTEGER uses two's complement with big endian, so we ensure the integer is
   // positive by keeping the leftmost octet below 128.
-  const unsignedInteger = new Uint8Array(potentiallySignedInteger);
-  unsignedInteger.set([Math.min(potentiallySignedInteger[0], 127)], 0);
+  const positiveInteger = new Uint8Array(potentiallySignedInteger);
+  positiveInteger.set([Math.min(potentiallySignedInteger[0], 127)], 0);
 
-  return new Integer({ valueHex: unsignedInteger });
+  return new Integer({ valueHex: positiveInteger });
 }
 
 //region Extensions

--- a/src/lib/nodes/errors.ts
+++ b/src/lib/nodes/errors.ts
@@ -4,4 +4,4 @@ import RelaynetError from '../RelaynetError';
 
 export class NodeError extends RelaynetError {}
 
-export class InvalidPublicNodeConnectionParams extends NodeError {}
+export class InvalidNodeConnectionParams extends NodeError {}


### PR DESCRIPTION
Part of https://github.com/relaycorp/relayverse/issues/19